### PR TITLE
Refine toggleable config strategy

### DIFF
--- a/src/providers/cmc/config/cmc-config.ts
+++ b/src/providers/cmc/config/cmc-config.ts
@@ -1,7 +1,5 @@
 // src/providers/cmc/config/cmc-config.ts
-import { registerAs } from '@nestjs/config';
 import { IsBoolean, IsInt, IsOptional, IsString, Min } from 'class-validator';
-import validateConfig from '../../../utils/validate-config';
 import { CmcConfig } from './cmc-config.type';
 import {
   CMC_DEFAULT_FIAT_CURRENCY,
@@ -13,10 +11,10 @@ import {
   CMC_TTL_MS,
 } from '../types/cmc-const.type';
 import { CmcEnvironmenType } from '../types/cmc-enum.type';
-import { parseBool } from '../../../config/config.helper';
 import { mapEnvType } from '../../../utils/helpers/env.helper';
+import { createToggleableConfig } from '../../../config/config.helper';
 
-class EnvironmentVariablesValidator {
+class CmcEnvironmentVariablesValidator {
   @IsString()
   CMC_API_KEY: string;
 
@@ -53,65 +51,70 @@ class EnvironmentVariablesValidator {
   CMC_DEFAULT_SYMBOLS?: string;
 }
 
-export default registerAs<CmcConfig>('cmc', () => {
-  validateConfig(process.env, EnvironmentVariablesValidator);
+function getDefaultSymbols(): string {
+  return Array.isArray(CMC_DEFAULT_SYMBOLS)
+    ? CMC_DEFAULT_SYMBOLS.map((s) => String(s).toUpperCase()).join(',')
+    : String(CMC_DEFAULT_SYMBOLS).toUpperCase();
+}
 
-  const apiKey = process.env.CMC_API_KEY as string; // validated as non-empty
+function normalizeSymbols(raw?: string): string {
+  if (raw && raw.length > 0) {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => s.toUpperCase())
+      .join(',');
+  }
+  return getDefaultSymbols();
+}
 
-  // Normalize enable flag from string envs ("true"/"false", "1"/"0", etc.) with const fallback
-  const enable = parseBool(process.env.CMC_ENABLE, CMC_ENABLE);
+const defaults: CmcConfig = {
+  enable: CMC_ENABLE,
+  apiKey: '',
+  envType: CMC_ENV_TYPE,
+  ttlMs: CMC_TTL_MS,
+  requestTimeoutMs: CMC_REQUEST_TIMEOUT_MS,
+  maxRetries: CMC_MAX_RETRIES,
+  defaultFiatCurrency: CMC_DEFAULT_FIAT_CURRENCY,
+  defaultSymbols: getDefaultSymbols(),
+};
 
-  // Normalize numeric values with safe fallbacks
-  const ttlMs = process.env.CMC_TTL_MS
-    ? parseInt(process.env.CMC_TTL_MS, 10)
-    : CMC_TTL_MS;
-  const requestTimeoutMs = process.env.CMC_REQUEST_TIMEOUT_MS
-    ? parseInt(process.env.CMC_REQUEST_TIMEOUT_MS, 10)
-    : CMC_REQUEST_TIMEOUT_MS;
-  const maxRetries = process.env.CMC_MAX_RETRIES
-    ? parseInt(process.env.CMC_MAX_RETRIES, 10)
-    : CMC_MAX_RETRIES;
+export default createToggleableConfig<CmcConfig, CmcEnvironmentVariablesValidator>(
+  'cmc',
+  CmcEnvironmentVariablesValidator,
+  defaults,
+  {
+    enableKey: 'enable',
+    enableEnvKey: 'CMC_ENABLE',
+    mapEnabledConfig: (env) => {
+      const ttlMs = env.CMC_TTL_MS ?? CMC_TTL_MS;
+      const requestTimeoutMs =
+        env.CMC_REQUEST_TIMEOUT_MS ?? CMC_REQUEST_TIMEOUT_MS;
+      const maxRetries = env.CMC_MAX_RETRIES ?? CMC_MAX_RETRIES;
 
-  // Map env type to enum
+      const envType = mapEnvType<CmcEnvironmenType>(
+        env.CMC_ENV_TYPE,
+        {
+          prod: CmcEnvironmenType.PRODUCTION,
+          production: CmcEnvironmenType.PRODUCTION,
+          sandbox: CmcEnvironmenType.SANDBOX,
+          dev: CmcEnvironmenType.SANDBOX,
+          development: CmcEnvironmenType.SANDBOX,
+        },
+        CMC_ENV_TYPE,
+      );
 
-  const envType = mapEnvType<CmcEnvironmenType>(
-    process.env.CMC_ENV_TYPE,
-    {
-      prod: CmcEnvironmenType.PRODUCTION,
-      production: CmcEnvironmenType.PRODUCTION,
-      sandbox: CmcEnvironmenType.SANDBOX,
-      dev: CmcEnvironmenType.SANDBOX,
-      development: CmcEnvironmenType.SANDBOX,
+      return {
+        apiKey: env.CMC_API_KEY,
+        envType,
+        ttlMs,
+        requestTimeoutMs,
+        maxRetries,
+        defaultFiatCurrency:
+          env.CMC_DEFAULT_FIAT_CURRENCY || CMC_DEFAULT_FIAT_CURRENCY,
+        defaultSymbols: normalizeSymbols(env.CMC_DEFAULT_SYMBOLS),
+      } satisfies Partial<CmcConfig>;
     },
-    CMC_ENV_TYPE,
-  );
-
-  // Normalize symbols: split, trim, uppercase, remove empties, join back
-  const defaultSymbols = (() => {
-    const raw = process.env.CMC_DEFAULT_SYMBOLS;
-    if (raw && raw.length > 0) {
-      return raw
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-        .map((s) => s.toUpperCase())
-        .join(',');
-    }
-    // Fallback to constant (string or string[])
-    return Array.isArray(CMC_DEFAULT_SYMBOLS)
-      ? CMC_DEFAULT_SYMBOLS.map((s) => String(s).toUpperCase()).join(',')
-      : String(CMC_DEFAULT_SYMBOLS).toUpperCase();
-  })();
-
-  return {
-    apiKey,
-    envType,
-    enable,
-    ttlMs,
-    requestTimeoutMs,
-    maxRetries,
-    defaultFiatCurrency:
-      process.env.CMC_DEFAULT_FIAT_CURRENCY || CMC_DEFAULT_FIAT_CURRENCY,
-    defaultSymbols,
-  };
-});
+  },
+);

--- a/src/providers/gorush/config/gorush.config.ts
+++ b/src/providers/gorush/config/gorush.config.ts
@@ -20,7 +20,7 @@ class EnvironmentVariablesValidator {
   GORUSH_REQUEST_TIMEOUT: number;
 }
 
-export default createToggleableConfig<GorushConfig>(
+export default createToggleableConfig<GorushConfig, EnvironmentVariablesValidator>(
   'gorush',
   EnvironmentVariablesValidator,
   {
@@ -28,6 +28,12 @@ export default createToggleableConfig<GorushConfig>(
     requestTimeOut: GORUSH_TIMEOUT_INTERVAL,
     enable: GORUSH_ENABLE,
   },
-  'enable',
-  'GORUSH_ENABLE',
+  {
+    enableKey: 'enable',
+    enableEnvKey: 'GORUSH_ENABLE',
+    mapEnabledConfig: (env) => ({
+      baseUrl: env.GORUSH_URL,
+      requestTimeOut: env.GORUSH_REQUEST_TIMEOUT,
+    }),
+  },
 );

--- a/src/providers/minio/config/minio.config.ts
+++ b/src/providers/minio/config/minio.config.ts
@@ -28,7 +28,7 @@ class MinioEnvValidator {
   MINIO_PORT: number;
 }
 
-export default createToggleableConfig<MinIOConfig>(
+export default createToggleableConfig<MinIOConfig, MinioEnvValidator>(
   'minIO',
   MinioEnvValidator,
   {
@@ -39,6 +39,15 @@ export default createToggleableConfig<MinIOConfig>(
     enable: MINIO_ENABLE,
     port: MINIO_PORT,
   },
-  'enable',
-  'MINIO_ENABLE',
+  {
+    enableKey: 'enable',
+    enableEnvKey: 'MINIO_ENABLE',
+    mapEnabledConfig: (env) => ({
+      host: env.MINIO_S3_HOST,
+      accessKey: env.MINIO_ACCESS_KEY,
+      secretKey: env.MINIO_SECRET_KEY,
+      useSSL: env.MINIO_USE_SSL,
+      port: env.MINIO_PORT,
+    }),
+  },
 );


### PR DESCRIPTION
## Summary
- enhance the shared toggleable config helper to parse enable flags with defaults and support custom environment mappers
- migrate the CMC, Gorush, and MinIO providers to use the shared helper so they short-circuit when disabled and only validate overrides when enabled

## Testing
- npm run lint *(fails: cannot find package '@typescript-eslint/eslint-plugin' in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_690c657a21a8832a9afcc4c120023cd1