### PR TITLE
Align toggleable service defaults

### DIFF
--- a/src/communication/socketio/config/socketio.config.ts
+++ b/src/communication/socketio/config/socketio.config.ts
@@ -1,5 +1,6 @@
-import { registerAs } from '@nestjs/config';
-import { parseBool } from '../../../config/config.helper';
+import { IsBoolean, IsInt, IsOptional, Min } from 'class-validator';
+import { createToggleableConfig } from '../../../config/config.helper';
+import { SocketIOConfig } from './socketio-config.type';
 import {
   SOCKETIO_DEFAULT_ENABLE,
   SOCKETIO_DEFAULT_PING_INTERVAL,
@@ -9,32 +10,64 @@ import {
   SOCKETIO_DEFAULT_MAX_REAUTH_TRIES,
 } from '../types/socketio-const.type';
 
-const intFromEnv = (key: string, fallback: number): number => {
-  const raw = process.env[key];
-  const n = parseInt(raw ?? '', 10);
-  return Number.isFinite(n) ? n : fallback;
+class SocketIoEnvironmentVariablesValidator {
+  @IsBoolean()
+  @IsOptional()
+  SOCKETIO_ENABLE?: boolean;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  SOCKETIO_PING_INTERVAL?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  SOCKETIO_PING_TIMEOUT?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  SOCKETIO_MAX_HTTP_BUFFER_SIZE?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  SOCKETIO_DEFAULT_REAUTH_GRACE_MS?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  SOCKETIO_MAX_REAUTH_TRIES?: number;
+}
+
+const defaults: SocketIOConfig = {
+  enable: SOCKETIO_DEFAULT_ENABLE,
+  pingInterval: SOCKETIO_DEFAULT_PING_INTERVAL,
+  pingTimeout: SOCKETIO_DEFAULT_PING_TIMEOUT,
+  maxHttpBufferSize: SOCKETIO_DEFAULT_MAX_HTTP_BUFFER_SIZE,
+  defaultReauthGraceMs: SOCKETIO_DEFAULT_REAUTH_GRACE_MS,
+  maxReauthTries: SOCKETIO_DEFAULT_MAX_REAUTH_TRIES,
 };
 
-export default registerAs('socketIO', () => ({
-  enable: parseBool(process.env.SOCKETIO_ENABLE, SOCKETIO_DEFAULT_ENABLE),
-  pingInterval: intFromEnv(
-    'SOCKETIO_PING_INTERVAL',
-    SOCKETIO_DEFAULT_PING_INTERVAL,
-  ),
-  pingTimeout: intFromEnv(
-    'SOCKETIO_PING_TIMEOUT',
-    SOCKETIO_DEFAULT_PING_TIMEOUT,
-  ),
-  maxHttpBufferSize: intFromEnv(
-    'SOCKETIO_MAX_HTTP_BUFFER_SIZE',
-    SOCKETIO_DEFAULT_MAX_HTTP_BUFFER_SIZE,
-  ),
-  defaultReauthGraceMs: intFromEnv(
-    'SOCKETIO_DEFAULT_REAUTH_GRACE_MS',
-    SOCKETIO_DEFAULT_REAUTH_GRACE_MS,
-  ),
-  maxReauthTries: intFromEnv(
-    'SOCKETIO_MAX_REAUTH_TRIES',
-    SOCKETIO_DEFAULT_MAX_REAUTH_TRIES,
-  ),
-}));
+export default createToggleableConfig<
+  SocketIOConfig,
+  SocketIoEnvironmentVariablesValidator
+>(
+  'socketIO',
+  SocketIoEnvironmentVariablesValidator,
+  defaults,
+  {
+    enableKey: 'enable',
+    enableEnvKey: 'SOCKETIO_ENABLE',
+    mapEnabledConfig: (env) => ({
+      pingInterval: env.SOCKETIO_PING_INTERVAL ?? defaults.pingInterval,
+      pingTimeout: env.SOCKETIO_PING_TIMEOUT ?? defaults.pingTimeout,
+      maxHttpBufferSize:
+        env.SOCKETIO_MAX_HTTP_BUFFER_SIZE ?? defaults.maxHttpBufferSize,
+      defaultReauthGraceMs:
+        env.SOCKETIO_DEFAULT_REAUTH_GRACE_MS ?? defaults.defaultReauthGraceMs,
+      maxReauthTries: env.SOCKETIO_MAX_REAUTH_TRIES ?? defaults.maxReauthTries,
+    }),
+  },
+);

--- a/src/providers/cmc/config/cmc-config.ts
+++ b/src/providers/cmc/config/cmc-config.ts
@@ -57,18 +57,6 @@ function getDefaultSymbols(): string {
     : String(CMC_DEFAULT_SYMBOLS).toUpperCase();
 }
 
-function normalizeSymbols(raw?: string): string {
-  if (raw && raw.length > 0) {
-    return raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((s) => s.toUpperCase())
-      .join(',');
-  }
-  return getDefaultSymbols();
-}
-
 const defaults: CmcConfig = {
   enable: CMC_ENABLE,
   apiKey: '',
@@ -80,6 +68,18 @@ const defaults: CmcConfig = {
   defaultSymbols: getDefaultSymbols(),
 };
 
+function normalizeSymbols(raw?: string): string {
+  if (raw && raw.length > 0) {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => s.toUpperCase())
+      .join(',');
+  }
+  return defaults.defaultSymbols;
+}
+
 export default createToggleableConfig<CmcConfig, CmcEnvironmentVariablesValidator>(
   'cmc',
   CmcEnvironmentVariablesValidator,
@@ -88,10 +88,10 @@ export default createToggleableConfig<CmcConfig, CmcEnvironmentVariablesValidato
     enableKey: 'enable',
     enableEnvKey: 'CMC_ENABLE',
     mapEnabledConfig: (env) => {
-      const ttlMs = env.CMC_TTL_MS ?? CMC_TTL_MS;
+      const ttlMs = env.CMC_TTL_MS ?? defaults.ttlMs;
       const requestTimeoutMs =
-        env.CMC_REQUEST_TIMEOUT_MS ?? CMC_REQUEST_TIMEOUT_MS;
-      const maxRetries = env.CMC_MAX_RETRIES ?? CMC_MAX_RETRIES;
+        env.CMC_REQUEST_TIMEOUT_MS ?? defaults.requestTimeoutMs;
+      const maxRetries = env.CMC_MAX_RETRIES ?? defaults.maxRetries;
 
       const envType = mapEnvType<CmcEnvironmenType>(
         env.CMC_ENV_TYPE,
@@ -102,7 +102,7 @@ export default createToggleableConfig<CmcConfig, CmcEnvironmentVariablesValidato
           dev: CmcEnvironmenType.SANDBOX,
           development: CmcEnvironmenType.SANDBOX,
         },
-        CMC_ENV_TYPE,
+        defaults.envType,
       );
 
       return {
@@ -112,7 +112,7 @@ export default createToggleableConfig<CmcConfig, CmcEnvironmentVariablesValidato
         requestTimeoutMs,
         maxRetries,
         defaultFiatCurrency:
-          env.CMC_DEFAULT_FIAT_CURRENCY || CMC_DEFAULT_FIAT_CURRENCY,
+          env.CMC_DEFAULT_FIAT_CURRENCY || defaults.defaultFiatCurrency,
         defaultSymbols: normalizeSymbols(env.CMC_DEFAULT_SYMBOLS),
       } satisfies Partial<CmcConfig>;
     },

--- a/src/providers/gorush/config/gorush.config.ts
+++ b/src/providers/gorush/config/gorush.config.ts
@@ -20,20 +20,22 @@ class EnvironmentVariablesValidator {
   GORUSH_REQUEST_TIMEOUT: number;
 }
 
+const defaults: GorushConfig = {
+  baseUrl: GORUSH_URL,
+  requestTimeOut: GORUSH_TIMEOUT_INTERVAL,
+  enable: GORUSH_ENABLE,
+};
+
 export default createToggleableConfig<GorushConfig, EnvironmentVariablesValidator>(
   'gorush',
   EnvironmentVariablesValidator,
-  {
-    baseUrl: GORUSH_URL,
-    requestTimeOut: GORUSH_TIMEOUT_INTERVAL,
-    enable: GORUSH_ENABLE,
-  },
+  defaults,
   {
     enableKey: 'enable',
     enableEnvKey: 'GORUSH_ENABLE',
     mapEnabledConfig: (env) => ({
-      baseUrl: env.GORUSH_URL,
-      requestTimeOut: env.GORUSH_REQUEST_TIMEOUT,
+      baseUrl: env.GORUSH_URL ?? defaults.baseUrl,
+      requestTimeOut: env.GORUSH_REQUEST_TIMEOUT ?? defaults.requestTimeOut,
     }),
   },
 );

--- a/src/providers/minio/config/minio.config.ts
+++ b/src/providers/minio/config/minio.config.ts
@@ -28,26 +28,28 @@ class MinioEnvValidator {
   MINIO_PORT: number;
 }
 
+const defaults: MinIOConfig = {
+  host: MINIO_S3_HOST,
+  accessKey: '',
+  secretKey: '',
+  useSSL: MINIO_USE_SSL,
+  enable: MINIO_ENABLE,
+  port: MINIO_PORT,
+};
+
 export default createToggleableConfig<MinIOConfig, MinioEnvValidator>(
   'minIO',
   MinioEnvValidator,
-  {
-    host: MINIO_S3_HOST,
-    accessKey: '',
-    secretKey: '',
-    useSSL: MINIO_USE_SSL,
-    enable: MINIO_ENABLE,
-    port: MINIO_PORT,
-  },
+  defaults,
   {
     enableKey: 'enable',
     enableEnvKey: 'MINIO_ENABLE',
     mapEnabledConfig: (env) => ({
-      host: env.MINIO_S3_HOST,
-      accessKey: env.MINIO_ACCESS_KEY,
-      secretKey: env.MINIO_SECRET_KEY,
-      useSSL: env.MINIO_USE_SSL,
-      port: env.MINIO_PORT,
+      host: env.MINIO_S3_HOST ?? defaults.host,
+      accessKey: env.MINIO_ACCESS_KEY ?? defaults.accessKey,
+      secretKey: env.MINIO_SECRET_KEY ?? defaults.secretKey,
+      useSSL: env.MINIO_USE_SSL ?? defaults.useSSL,
+      port: env.MINIO_PORT ?? defaults.port,
     }),
   },
 );


### PR DESCRIPTION
## Summary
- refactor the CMC, MinIO, and Gorush providers to define shared defaults constants when using createToggleableConfig
- ensure runtime overrides fall back to the shared defaults rather than raw constants for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690cac1e7fb8832a8362c92ea939fb78