### PR TITLE
Fix i18n asset loader path

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -65,7 +65,7 @@ const infrastructureDatabaseModule = (databaseConfig() as DatabaseConfig)
           infer: true,
         }),
         loaderOptions: {
-          path: path.join(__dirname, '/i18n/'),
+          path: path.join(__dirname, '../i18n/'),
           watch: true,
         },
       }),


### PR DESCRIPTION
## Summary
- point the i18n asset loader to the compiled translations directory to prevent runtime lookup failures

## Testing
- npm run build (fails: rimraf: not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691220286084832a9b5fa0cf6796b097)