### PR TITLE
Align relational docker compose with base configuration

### DIFF
--- a/docker-compose.relational.ci.yaml
+++ b/docker-compose.relational.ci.yaml
@@ -8,10 +8,15 @@ services:
       - 5432
     env_file:
       - env-example-relational
-    # environment:
-    #   POSTGRES_USER: ${DATABASE_USERNAME}
-    #   POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-    #   POSTGRES_DB: ${DATABASE_NAME}
+    environment:
+      POSTGRES_USER: ${DATABASE_USERNAME:-root}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-secret}
+      POSTGRES_DB: ${DATABASE_NAME:-api}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USERNAME:-root}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   maildev:
     build:
@@ -43,6 +48,13 @@ services:
       dockerfile: relational.test.Dockerfile
     networks:
       - default
+    depends_on:
+      postgres:
+        condition: service_healthy
+      maildev:
+        condition: service_started
+      redis:
+        condition: service_started
     expose:
       - 3000
       - 4000

--- a/docker-compose.relational.test.yaml
+++ b/docker-compose.relational.test.yaml
@@ -5,10 +5,15 @@ services:
       - 5432
     env_file:
       - env-example-relational
-    # environment:
-    #   POSTGRES_USER: ${DATABASE_USERNAME}
-    #   POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-    #   POSTGRES_DB: ${DATABASE_NAME}
+    environment:
+      POSTGRES_USER: ${DATABASE_USERNAME:-root}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-secret}
+      POSTGRES_DB: ${DATABASE_NAME:-api}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USERNAME:-root}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   maildev:
     build:
@@ -32,6 +37,13 @@ services:
     build:
       context: .
       dockerfile: relational.test.Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      maildev:
+        condition: service_started
+      redis:
+        condition: service_started
     expose:
       - 3000
       - 4000


### PR DESCRIPTION
## Summary
- configure the relational CI and test postgres services with explicit credentials like the base compose file
- add healthchecks and dependency ordering to ensure api waits for postgres, maildev, and redis

## Testing
- not run (docker is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691248f48d50832a82dc339b27b8ecc5)