### PR TITLE
Enhance AWS Secrets Manager sandbox support and logging

### DIFF
--- a/env-example-relational
+++ b/env-example-relational
@@ -85,6 +85,15 @@ REDIS_WORKER_URL=redis://redis:6379/4
 GLOBAL_SECRET_PATH="files/secrets"
 
 ########################################
+# AWS Secrets Manager
+########################################
+AWS_SECRETS_MANAGER_ENABLE=false
+AWS_SECRETS_MANAGER_REGION=
+AWS_SECRETS_MANAGER_SECRET_IDS=
+AWS_SECRETS_MANAGER_SET_TO_ENV=true
+AWS_SECRETS_MANAGER_DEBUG=false
+
+########################################
 # Notifications - Gorush
 ########################################
 GORUSH_REQUEST_TIMEOUT=5000

--- a/src/config/aws-secrets-manager.bootstrap.ts
+++ b/src/config/aws-secrets-manager.bootstrap.ts
@@ -11,14 +11,17 @@ export async function bootstrapAwsSecrets(): Promise<void> {
   const logger = new Logger('AwsSecretsBootstrap');
   const config = buildAwsSecretsOptionsFromEnv();
   const nodeEnv = process.env.NODE_ENV || NodeEnv.DEVELOPMENT;
+  const allowedEnvironments = [NodeEnv.PRODUCTION, NodeEnv.SANDBOX];
 
   if (!config.enable) {
     logger.log('AWS Secrets Manager bootstrap disabled.');
     return;
   }
 
-  if (nodeEnv !== NodeEnv.PRODUCTION) {
-    logger.log(`AWS Secrets Manager bootstrap skipped for ${nodeEnv} environment.`);
+  if (!allowedEnvironments.includes(nodeEnv as NodeEnv)) {
+    logger.log(
+      `AWS Secrets Manager bootstrap skipped for ${nodeEnv} environment. Allowed environments: ${allowedEnvironments.join(', ')}.`,
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
- add AWS Secrets Manager environment variables to the relational example
- allow AWS Secrets Manager bootstrap to run in sandbox environments alongside production
- expand AWS Secrets Manager service logging and error handling when syncing or retrieving secrets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693687c276f4832a8f3d04210b7e4aa2)