### PR TITLE
Replace nestjs-aws-secrets-manager dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "ms": "2.1.3",
         "multer": "2.0.2",
         "multer-s3": "3.0.1",
-        "nestjs-aws-secrets-manager": "^1.1.3",
         "nestjs-i18n": "10.5.1",
         "nodemailer": "7.0.7",
         "passport": "0.7.0",
@@ -2687,7 +2686,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2700,7 +2699,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -4819,7 +4818,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4840,7 +4839,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -6424,6 +6423,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@scalar/nestjs-api-reference": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@scalar/nestjs-api-reference/-/nestjs-api-reference-0.4.16.tgz",
@@ -7665,28 +7682,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -9187,7 +9204,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -9223,7 +9240,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -9476,7 +9493,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -11328,7 +11345,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -11656,7 +11673,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -12588,6 +12605,64 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/exsolve": {
@@ -18326,7 +18401,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -18845,16 +18920,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
-    },
-    "node_modules/nestjs-aws-secrets-manager": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/nestjs-aws-secrets-manager/-/nestjs-aws-secrets-manager-1.1.3.tgz",
-      "integrity": "sha512-c9jmpA5VD/49hHrxHFULYbPt/elU5FBXXQ41yWR9DcKZkirQMakEMC/HSp1MHUg0NqRkx9FPCmIuwdNEffLKCw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.0.0",
-        "@nestjs/common": "^8.0.0 || ^9.0.0"
-      }
     },
     "node_modules/nestjs-i18n": {
       "version": "10.5.1",
@@ -22918,7 +22983,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -23339,7 +23404,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -23629,7 +23694,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -23754,6 +23819,56 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webpack": {
+      "version": "5.103.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
+      "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.26.3",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.3",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.11",
+        "watchpack": "^2.4.4",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
@@ -23772,6 +23887,97 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/which": {
@@ -24254,7 +24460,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "ms": "2.1.3",
     "multer": "2.0.2",
     "multer-s3": "3.0.1",
-    "nestjs-aws-secrets-manager": "^1.1.3",
     "nestjs-i18n": "10.5.1",
     "nodemailer": "7.0.7",
     "passport": "0.7.0",

--- a/src/common/secret/aws-secrets-manager.client.ts
+++ b/src/common/secret/aws-secrets-manager.client.ts
@@ -1,0 +1,74 @@
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+import { Logger } from '@nestjs/common';
+
+export interface AwsSecretsManagerOptions {
+  secretsManager: SecretsManagerClient;
+  secretsSource?: string | string[];
+  isSetToEnv?: boolean;
+  isDebug?: boolean;
+}
+
+export class AwsSecretsManagerClient {
+  private readonly logger = new Logger(AwsSecretsManagerClient.name);
+
+  constructor(private readonly options: AwsSecretsManagerOptions) {}
+
+  async setAllSecretsToEnv(): Promise<void> {
+    const sources = this.normalizeSources();
+    if (sources.length === 0) return;
+
+    for (const secretId of sources) {
+      const secret = await this.getSecretsByID<Record<string, unknown>>(secretId);
+      if (!this.options.isSetToEnv) continue;
+
+      if (secret && typeof secret === 'object') {
+        Object.entries(secret).forEach(([key, value]) => {
+          const stringValue = value?.toString();
+          if (stringValue === undefined) return;
+          process.env[key] = stringValue;
+          if (this.options.isDebug) {
+            this.logger.debug(`Set env ${key} from secret ${secretId}`);
+          }
+        });
+      } else if (this.options.isDebug) {
+        this.logger.debug(`Secret ${secretId} is not an object and was not applied to env.`);
+      }
+    }
+  }
+
+  async getSecretsByID<T>(secretId: string): Promise<T> {
+    const response = await this.options.secretsManager.send(
+      new GetSecretValueCommand({ SecretId: secretId }),
+    );
+
+    const secretValue =
+      response.SecretString ??
+      (response.SecretBinary
+        ? Buffer.from(response.SecretBinary).toString('utf-8')
+        : undefined);
+
+    if (secretValue === undefined) {
+      throw new Error(`Secret ${secretId} returned no data.`);
+    }
+
+    try {
+      return JSON.parse(secretValue) as T;
+    } catch (error) {
+      if (this.options.isDebug) {
+        this.logger.debug(
+          `Secret ${secretId} is not JSON. Returning raw string. Error: ${(error as Error).message}`,
+        );
+      }
+      return secretValue as unknown as T;
+    }
+  }
+
+  private normalizeSources(): string[] {
+    const { secretsSource } = this.options;
+    if (!secretsSource) return [];
+    return Array.isArray(secretsSource) ? secretsSource : [secretsSource];
+  }
+}

--- a/src/common/secret/aws-secrets-manager.service.ts
+++ b/src/common/secret/aws-secrets-manager.service.ts
@@ -1,12 +1,12 @@
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-  AWSSecretsManagerModuleOptions,
-  AWSSecretsService,
-} from 'nestjs-aws-secrets-manager';
 import { AllConfigType } from 'src/config/config.type';
 import { AwsSecretsManagerConfig } from 'src/config/types/aws-secrets-manager-config.type';
+import {
+  AwsSecretsManagerClient,
+  AwsSecretsManagerOptions,
+} from './aws-secrets-manager.client';
 import { BaseToggleableService } from '../base/base-toggleable.service';
 import { buildAwsSecretsOptionsFromEnv } from 'src/config/aws-secrets-manager.config';
 
@@ -66,10 +66,10 @@ export class AwsSecretsManagerService
       )}) to populate environment variables...`,
     );
 
-    try {
-      const secretsService = new AWSSecretsService(options);
-      await secretsService.setAllSecrectToEnv();
+    const secretsService = new AwsSecretsManagerClient(options);
 
+    try {
+      await secretsService.setAllSecretsToEnv();
       this.logger.log(
         `${context}: AWS secrets loaded into process.env and ready for ConfigService consumers.`,
       );
@@ -103,7 +103,7 @@ export class AwsSecretsManagerService
       this.logger.log(
         `Fetching AWS secret "${secretId}" using region ${this.secretsConfig.region}...`,
       );
-      const secretsService = new AWSSecretsService(options);
+      const secretsService = new AwsSecretsManagerClient(options);
       const secret = await secretsService.getSecretsByID<T>(secretId);
       this.logger.log(`AWS secret "${secretId}" successfully retrieved.`);
       return secret;
@@ -116,7 +116,7 @@ export class AwsSecretsManagerService
     }
   }
 
-  private buildOptions(): AWSSecretsManagerModuleOptions {
+  private buildOptions(): AwsSecretsManagerOptions {
     const secretsSource =
       this.secretsConfig.secretIds.length === 1
         ? this.secretsConfig.secretIds[0]

--- a/src/config/aws-secrets-manager.bootstrap.ts
+++ b/src/config/aws-secrets-manager.bootstrap.ts
@@ -1,11 +1,11 @@
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { Logger } from '@nestjs/common';
-import {
-  AWSSecretsManagerModuleOptions,
-  AWSSecretsService,
-} from 'nestjs-aws-secrets-manager';
 import { NodeEnv } from 'src/utils/types/gobal.type';
 import { buildAwsSecretsOptionsFromEnv } from './aws-secrets-manager.config';
+import {
+  AwsSecretsManagerClient,
+  AwsSecretsManagerOptions,
+} from 'src/common/secret/aws-secrets-manager.client';
 
 export async function bootstrapAwsSecrets(): Promise<void> {
   const logger = new Logger('AwsSecretsBootstrap');
@@ -37,7 +37,7 @@ export async function bootstrapAwsSecrets(): Promise<void> {
     return;
   }
 
-  const options: AWSSecretsManagerModuleOptions = {
+  const options: AwsSecretsManagerOptions = {
     secretsManager: new SecretsManagerClient({ region: config.region }),
     isSetToEnv: config.setToEnv,
     secretsSource: source,
@@ -49,8 +49,8 @@ export async function bootstrapAwsSecrets(): Promise<void> {
   );
 
   try {
-    const secretsService = new AWSSecretsService(options);
-    await secretsService.setAllSecrectToEnv();
+    const secretsService = new AwsSecretsManagerClient(options);
+    await secretsService.setAllSecretsToEnv();
     logger.log('AWS secrets loaded into environment variables.');
   } catch (error) {
     logger.error(`Failed to preload AWS secrets: ${(error as Error).message}`);


### PR DESCRIPTION
## Summary
- replace the nestjs-aws-secrets-manager dependency with a custom AWS Secrets Manager client built on the AWS SDK
- update bootstrap and service logic to use the internal client while retaining environment loading behavior
- refresh the package lock after removing the incompatible dependency

## Testing
- npm install --package-lock-only --ignore-scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368ef886f0832a82730fe707a76411)