### PR TITLE
Replace deprecated Swagger base path configuration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,17 +64,17 @@ async function bootstrap() {
     new StandardResponseInterceptor(),
   );
 
+  const apiPrefix = configService.getOrThrow('app.apiPrefix', {
+    infer: true,
+  });
+
   const builder = new DocumentBuilder()
     .setTitle(APP.name)
     .setDescription(
       '![NestJS](https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white) ![Swagger](https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white) ![ReadTheDocs](https://img.shields.io/badge/Readthedocs-%23000000.svg?style=for-the-badge&logo=readthedocs&logoColor=white)',
     )
     .setLicense('MIT', 'https://opensource.org/license/mit/')
-    .setBasePath(
-      `/${configService.getOrThrow('app.apiPrefix', {
-        infer: true,
-      })}`,
-    )
+    .addServer(`/${apiPrefix}`)
     .setExternalDoc(
       'Documentation',
       configService.get(


### PR DESCRIPTION
## Summary
- replace deprecated Swagger `setBasePath` usage with `addServer` configured from the API prefix
- reuse the resolved API prefix when building the Swagger document

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936919caea0832ab2582c993ea5eddd)