### PR TITLE
Add wallet provider registry scaffolding

### DIFF
--- a/src/wallets/domain/ports/sub-wallet.port.ts
+++ b/src/wallets/domain/ports/sub-wallet.port.ts
@@ -1,0 +1,23 @@
+import { Wallet } from '../wallet';
+
+export interface SubWalletPort {
+  /**
+   * Provider identifier used to match wallet provider value.
+   */
+  readonly provider: Wallet['provider'];
+
+  /**
+   * Provision or return a blockchain address for the wallet.
+   */
+  createAddress?(wallet: Wallet): Promise<unknown>;
+
+  /**
+   * Fetch current balances for the wallet.
+   */
+  getBalance?(wallet: Wallet): Promise<unknown>;
+
+  /**
+   * Initiate a transfer for the wallet.
+   */
+  initiateTransfer?(wallet: Wallet, payload: unknown): Promise<unknown>;
+}

--- a/src/wallets/provider-registry/crypto-provider.enum.ts
+++ b/src/wallets/provider-registry/crypto-provider.enum.ts
@@ -1,0 +1,31 @@
+import { Wallet } from '../domain/wallet';
+
+/**
+ * Dynamic enum-like registry for supported crypto wallet providers.
+ * Providers should call `CryptoProviderEnum.register()` during setup so
+ * services and controllers can reference the canonical provider list.
+ */
+export class CryptoProviderEnum {
+  private static providers = new Map<string, Wallet['provider']>();
+
+  private static normalizeKey(provider: Wallet['provider']): string {
+    return provider.toString().toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  }
+
+  static register(provider: Wallet['provider']): void {
+    const key = this.normalizeKey(provider);
+    this.providers.set(key, provider);
+  }
+
+  static values(): Wallet['provider'][] {
+    return Array.from(this.providers.values());
+  }
+
+  static toRecord(): Record<string, Wallet['provider']> {
+    return Object.fromEntries(this.providers);
+  }
+
+  static has(provider: Wallet['provider']): boolean {
+    return this.values().includes(provider);
+  }
+}

--- a/src/wallets/provider-registry/wallet-provider.factory.ts
+++ b/src/wallets/provider-registry/wallet-provider.factory.ts
@@ -1,0 +1,46 @@
+import { HttpStatus, Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { Wallet } from '../domain/wallet';
+import { SubWalletPort } from '../domain/ports/sub-wallet.port';
+import { TypeMessage } from '../../utils/types/message.type';
+import { CryptoProviderEnum } from './crypto-provider.enum';
+
+export const WALLET_PROVIDER_ADAPTERS = 'WALLET_PROVIDER_ADAPTERS';
+
+@Injectable()
+export class WalletProviderFactory {
+  constructor(
+    @Inject(WALLET_PROVIDER_ADAPTERS)
+    private readonly adapters: SubWalletPort[],
+  ) {
+    this.registerProviders();
+  }
+
+  private registerProviders(): void {
+    this.adapters.forEach((adapter) => {
+      CryptoProviderEnum.register(adapter.provider);
+    });
+  }
+
+  resolve(provider: Wallet['provider']): SubWalletPort | undefined {
+    return this.adapters.find((adapter) => adapter.provider === provider);
+  }
+
+  validateProviderSupport(provider: Wallet['provider']): void {
+    if (!this.adapters.length) {
+      return;
+    }
+
+    const adapter = this.resolve(provider);
+    if (!adapter) {
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        message: TypeMessage.getMessageByStatus(HttpStatus.UNPROCESSABLE_ENTITY),
+        errors: { provider: 'WalletProviderNotSupported' },
+      });
+    }
+  }
+
+  getRegisteredProviders(): Wallet['provider'][] {
+    return this.adapters.map((adapter) => adapter.provider);
+  }
+}

--- a/src/wallets/wallets.module.ts
+++ b/src/wallets/wallets.module.ts
@@ -6,6 +6,10 @@ import {
 import { WalletsService } from './wallets.service';
 import { WalletsController } from './wallets.controller';
 import { RelationalWalletPersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
+import {
+  WALLET_PROVIDER_ADAPTERS,
+  WalletProviderFactory,
+} from './provider-registry/wallet-provider.factory';
 
 @Module({
   imports: [
@@ -15,7 +19,16 @@ import { RelationalWalletPersistenceModule } from './infrastructure/persistence/
     RelationalWalletPersistenceModule,
   ],
   controllers: [WalletsController],
-  providers: [WalletsService],
-  exports: [WalletsService, RelationalWalletPersistenceModule],
+  providers: [
+    WalletsService,
+    WalletProviderFactory,
+    { provide: WALLET_PROVIDER_ADAPTERS, useValue: [] },
+  ],
+  exports: [
+    WalletsService,
+    RelationalWalletPersistenceModule,
+    WalletProviderFactory,
+    WALLET_PROVIDER_ADAPTERS,
+  ],
 })
 export class WalletsModule {}

--- a/src/wallets/wallets.service.ts
+++ b/src/wallets/wallets.service.ts
@@ -18,12 +18,14 @@ import {
   GroupPlainToInstance,
   GroupPlainToInstances,
 } from '../utils/transformers/class.transformer';
+import { WalletProviderFactory } from './provider-registry/wallet-provider.factory';
 
 @Injectable()
 export class WalletsService {
   constructor(
     private readonly userService: UsersService,
     private readonly walletRepository: WalletRepository,
+    private readonly walletProviderFactory: WalletProviderFactory,
   ) {}
 
   async create(createWalletDto: CreateWalletDto): Promise<WalletDto> {
@@ -37,6 +39,8 @@ export class WalletsService {
         errors: { user: 'UserNotExist' },
       });
     }
+
+    this.walletProviderFactory.validateProviderSupport(createWalletDto.provider);
 
     const wallet = await this.walletRepository.create({
       active: createWalletDto.active,
@@ -63,6 +67,10 @@ export class WalletsService {
         errors: { user: 'UserNotExist' },
       });
     }
+
+    this.walletProviderFactory.validateProviderSupport(
+      createWalletUserDto.provider,
+    );
 
     const created = await this.walletRepository.create({
       user,
@@ -130,6 +138,12 @@ export class WalletsService {
         });
       }
       user = userObject;
+    }
+
+    if (updateWalletDto.provider) {
+      this.walletProviderFactory.validateProviderSupport(
+        updateWalletDto.provider,
+      );
     }
 
     const updated = await this.walletRepository.update(id, {


### PR DESCRIPTION
## Summary
- define a SubWalletPort contract for provider-specific wallet capabilities
- add a WalletProviderFactory and registry token to resolve or validate provider adapters
- integrate the provider factory into the wallets module and service to support provider-aware validation
- introduce a dynamic CryptoProviderEnum registry and auto-register providers from configured adapters

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d3528798832a9b1de50635c0d33b)