### PR TITLE
Fix fireblocks CW import paths and config typing

### DIFF
--- a/src/providers/fireblocks/cw/core/providers/fireblocks-client.provider.ts
+++ b/src/providers/fireblocks/cw/core/providers/fireblocks-client.provider.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AllConfigType } from '../../../../config/config.type';
+import { AllConfigType } from '../../../../../config/config.type';
 import { FireblocksClientOptions } from '../../types/fireblocks-base.type';
 
 @Injectable()
@@ -16,7 +16,7 @@ export class FireblocksClientProvider {
         infer: true,
       }),
       basePath: this.configService.get('fireblocks.basePath', { infer: true }) ?? '',
-      envType: this.configService.get('fireblocks.envType', { infer: true }) ?? '',
+      envType: this.configService.getOrThrow('fireblocks.envType', { infer: true }),
     };
     this.logger.log(
       `Fireblocks client configured (env: ${this.options.envType}, basePath: ${this.options.basePath})`,

--- a/src/providers/fireblocks/cw/deposit/cw-deposit.module.ts
+++ b/src/providers/fireblocks/cw/deposit/cw-deposit.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
+import { FireblocksCoreModule } from '../core/fireblocks-core.module';
 import { CwDepositService } from './cw-deposit.service';
 
 @Module({

--- a/src/providers/fireblocks/cw/deposit/cw-deposit.service.ts
+++ b/src/providers/fireblocks/cw/deposit/cw-deposit.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwDepositService {

--- a/src/providers/fireblocks/cw/portfolio/cw-portfolio.module.ts
+++ b/src/providers/fireblocks/cw/portfolio/cw-portfolio.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
+import { FireblocksCoreModule } from '../core/fireblocks-core.module';
 import { CwPortfolioService } from './cw-portfolio.service';
 
 @Module({

--- a/src/providers/fireblocks/cw/portfolio/cw-portfolio.service.ts
+++ b/src/providers/fireblocks/cw/portfolio/cw-portfolio.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwPortfolioService {

--- a/src/providers/fireblocks/cw/transactions/cw-transactions.module.ts
+++ b/src/providers/fireblocks/cw/transactions/cw-transactions.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
+import { FireblocksCoreModule } from '../core/fireblocks-core.module';
 import { CwTransactionsService } from './cw-transactions.service';
 
 @Module({

--- a/src/providers/fireblocks/cw/transactions/cw-transactions.service.ts
+++ b/src/providers/fireblocks/cw/transactions/cw-transactions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwTransactionsService {

--- a/src/providers/fireblocks/cw/transfers/cw-transfers.module.ts
+++ b/src/providers/fireblocks/cw/transfers/cw-transfers.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
+import { FireblocksCoreModule } from '../core/fireblocks-core.module';
 import { CwTransfersService } from './cw-transfers.service';
 
 @Module({

--- a/src/providers/fireblocks/cw/transfers/cw-transfers.service.ts
+++ b/src/providers/fireblocks/cw/transfers/cw-transfers.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
-import { FireblocksErrorMapper } from '../../core/providers/fireblocks-error-mapper';
-import { FireblocksResilience } from '../../core/providers/fireblocks-resilience';
+import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
+import { FireblocksErrorMapper } from '../core/providers/fireblocks-error-mapper';
+import { FireblocksResilience } from '../core/providers/fireblocks-resilience';
 
 export interface TransferCommand {
   source: string;


### PR DESCRIPTION
## Summary
- fix Fireblocks config import and ensure envType is required from configuration
- correct relative imports for Fireblocks CW modules and services pointing to core providers

## Testing
- npm run lint -- src/providers/fireblocks/cw *(fails: missing @typescript-eslint/eslint-plugin dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693849457ea0832ab9d2ff7772a949ec)