### PR TITLE
Rename Fireblocks CW unified module references

### DIFF
--- a/src/providers/fireblocks/cw/core/fireblocks-cw-unified.module.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-cw-unified.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { FireblocksCoreModule } from './fireblocks-core.module';
+import { FireblocksCwUnifiedService } from './fireblocks-cw-unified.service';
+import { AdminAuditModule } from './modules/admin-audit.module';
+import { AdminDestinationsModule } from './modules/admin-destinations.module';
+import { AdminGasOperationsModule } from './modules/admin-gas-operations.module';
+import { AdminSecurityModule } from './modules/admin-security.module';
+import { AdminWithdrawalsModule } from './modules/admin-withdrawals.module';
+import { CwDepositModule } from './modules/cw-deposit.module';
+import { CwPortfolioModule } from './modules/cw-portfolio.module';
+import { CwTransactionsModule } from './modules/cw-transactions.module';
+import { CwTransfersModule } from './modules/cw-transfers.module';
+
+const ADMIN_MODULES = [
+  AdminSecurityModule,
+  AdminDestinationsModule,
+  AdminWithdrawalsModule,
+  AdminGasOperationsModule,
+  AdminAuditModule,
+];
+
+const NON_ADMIN_MODULES = [
+  CwDepositModule,
+  CwPortfolioModule,
+  CwTransfersModule,
+  CwTransactionsModule,
+];
+
+@Module({
+  imports: [FireblocksCoreModule, ...ADMIN_MODULES, ...NON_ADMIN_MODULES],
+  providers: [FireblocksCwUnifiedService],
+  exports: [
+    FireblocksCoreModule,
+    FireblocksCwUnifiedService,
+    ...ADMIN_MODULES,
+    ...NON_ADMIN_MODULES,
+  ],
+})
+export class FireblocksCwUnifiedModule {}

--- a/src/providers/fireblocks/cw/core/fireblocks-cw-unified.service.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-cw-unified.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, Type } from '@nestjs/common';
+import { AdminAuditModule } from './modules/admin-audit.module';
+import { AdminDestinationsModule } from './modules/admin-destinations.module';
+import { AdminGasOperationsModule } from './modules/admin-gas-operations.module';
+import { AdminSecurityModule } from './modules/admin-security.module';
+import { AdminWithdrawalsModule } from './modules/admin-withdrawals.module';
+import { CwDepositModule } from './modules/cw-deposit.module';
+import { CwPortfolioModule } from './modules/cw-portfolio.module';
+import { CwTransactionsModule } from './modules/cw-transactions.module';
+import { CwTransfersModule } from './modules/cw-transfers.module';
+
+const ADMIN_MODULES: Array<Type> = [
+  AdminSecurityModule,
+  AdminDestinationsModule,
+  AdminWithdrawalsModule,
+  AdminGasOperationsModule,
+  AdminAuditModule,
+];
+
+const NON_ADMIN_MODULES: Array<Type> = [
+  CwDepositModule,
+  CwPortfolioModule,
+  CwTransfersModule,
+  CwTransactionsModule,
+];
+
+@Injectable()
+export class FireblocksCwUnifiedService {
+  getAdminModules(): Array<Type> {
+    return [...ADMIN_MODULES];
+  }
+
+  getNonAdminModules(): Array<Type> {
+    return [...NON_ADMIN_MODULES];
+  }
+
+  getAllModules(): Array<Type> {
+    return [...ADMIN_MODULES, ...NON_ADMIN_MODULES];
+  }
+}

--- a/src/providers/fireblocks/cw/core/modules/admin-audit.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/admin-audit.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
-import { AdminAuditService } from './admin-audit.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { AdminAuditService } from '../services/admin-audit.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/admin-destinations.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/admin-destinations.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
-import { AdminDestinationsService } from './admin-destinations.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { AdminDestinationsService } from '../services/admin-destinations.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/admin-gas-operations.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/admin-gas-operations.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
-import { AdminGasOperationsService } from './admin-gas-operations.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { AdminGasOperationsService } from '../services/admin-gas-operations.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/admin-security.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/admin-security.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
-import { AdminSecurityService } from './admin-security.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { AdminSecurityService } from '../services/admin-security.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/admin-withdrawals.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/admin-withdrawals.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../../core/fireblocks-core.module';
-import { AdminWithdrawalsService } from './admin-withdrawals.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { AdminWithdrawalsService } from '../services/admin-withdrawals.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/cw-deposit.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-deposit.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../core/fireblocks-core.module';
-import { CwDepositService } from './cw-deposit.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { CwDepositService } from '../services/cw-deposit.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/cw-portfolio.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-portfolio.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../core/fireblocks-core.module';
-import { CwPortfolioService } from './cw-portfolio.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { CwPortfolioService } from '../services/cw-portfolio.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/cw-transactions.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-transactions.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../core/fireblocks-core.module';
-import { CwTransactionsService } from './cw-transactions.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { CwTransactionsService } from '../services/cw-transactions.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/modules/cw-transfers.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-transfers.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from '../core/fireblocks-core.module';
-import { CwTransfersService } from './cw-transfers.service';
+import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { CwTransfersService } from '../services/cw-transfers.service';
 
 @Module({
   imports: [FireblocksCoreModule],

--- a/src/providers/fireblocks/cw/core/services/admin-audit.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-audit.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class AdminAuditService {

--- a/src/providers/fireblocks/cw/core/services/admin-destinations.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-destinations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class AdminDestinationsService {

--- a/src/providers/fireblocks/cw/core/services/admin-gas-operations.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-gas-operations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class AdminGasOperationsService {

--- a/src/providers/fireblocks/cw/core/services/admin-security.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-security.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksResilience } from '../../core/providers/fireblocks-resilience';
+import { FireblocksResilience } from '../providers/fireblocks-resilience';
 
 @Injectable()
 export class AdminSecurityService {

--- a/src/providers/fireblocks/cw/core/services/admin-withdrawals.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-withdrawals.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksErrorMapper } from '../../core/providers/fireblocks-error-mapper';
+import { FireblocksErrorMapper } from '../providers/fireblocks-error-mapper';
 
 @Injectable()
 export class AdminWithdrawalsService {

--- a/src/providers/fireblocks/cw/core/services/cw-deposit.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-deposit.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwDepositService {

--- a/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwPortfolioService {

--- a/src/providers/fireblocks/cw/core/services/cw-transactions.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-transactions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
 
 @Injectable()
 export class CwTransactionsService {

--- a/src/providers/fireblocks/cw/core/services/cw-transfers.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-transfers.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksClientProvider } from '../core/providers/fireblocks-client.provider';
-import { FireblocksErrorMapper } from '../core/providers/fireblocks-error-mapper';
-import { FireblocksResilience } from '../core/providers/fireblocks-resilience';
+import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
+import { FireblocksErrorMapper } from '../providers/fireblocks-error-mapper';
+import { FireblocksResilience } from '../providers/fireblocks-resilience';
 
 export interface TransferCommand {
   source: string;

--- a/src/providers/fireblocks/cw/fireblocks-cw.module.ts
+++ b/src/providers/fireblocks/cw/fireblocks-cw.module.ts
@@ -1,42 +1,15 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCoreModule } from './core/fireblocks-core.module';
+import { FireblocksCwUnifiedModule } from './core/fireblocks-cw-unified.module';
 import { FireblocksWebhookModule } from './webhook/fireblocks-webhook.module';
-import { CwDepositModule } from './deposit/cw-deposit.module';
-import { CwPortfolioModule } from './portfolio/cw-portfolio.module';
-import { CwTransfersModule } from './transfers/cw-transfers.module';
-import { CwTransactionsModule } from './transactions/cw-transactions.module';
-import { AdminSecurityModule } from './admin/security/admin-security.module';
-import { AdminDestinationsModule } from './admin/destinations/admin-destinations.module';
-import { AdminWithdrawalsModule } from './admin/withdrawals/admin-withdrawals.module';
-import { AdminGasOperationsModule } from './admin/gas/admin-gas-operations.module';
-import { AdminAuditModule } from './admin/audit/admin-audit.module';
 
 @Module({
   imports: [
-    FireblocksCoreModule,
     FireblocksWebhookModule,
-    CwDepositModule,
-    CwPortfolioModule,
-    CwTransfersModule,
-    CwTransactionsModule,
-    AdminSecurityModule,
-    AdminDestinationsModule,
-    AdminWithdrawalsModule,
-    AdminGasOperationsModule,
-    AdminAuditModule,
+    FireblocksCwUnifiedModule,
   ],
   exports: [
-    FireblocksCoreModule,
     FireblocksWebhookModule,
-    CwDepositModule,
-    CwPortfolioModule,
-    CwTransfersModule,
-    CwTransactionsModule,
-    AdminSecurityModule,
-    AdminDestinationsModule,
-    AdminWithdrawalsModule,
-    AdminGasOperationsModule,
-    AdminAuditModule,
+    FireblocksCwUnifiedModule,
   ],
 })
 export class FireblocksCwModule {}


### PR DESCRIPTION
## Summary
- rename Fireblocks CW aggregation module and service to use the unified naming
- update Fireblocks CW module imports/exports to reference the unified module

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69393ecea46c832a88a4755387930f96)