### PR TITLE
Refactor Fireblocks CW registry and mapper structure

### DIFF
--- a/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { FireblocksClientProvider } from './providers/fireblocks-client.provider';
-import { FireblocksErrorMapper } from './providers/fireblocks-error-mapper';
+import { FireblocksErrorMapper } from '../infrastructure/persistence/relational/mappers/fireblocks-error.mapper';
 import { FireblocksResilience } from './providers/fireblocks-resilience';
 
 @Module({

--- a/src/providers/fireblocks/cw/core/fireblocks-cw-registry.module.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-cw-registry.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { FireblocksCoreModule } from './fireblocks-core.module';
-import { FireblocksCwUnifiedService } from './fireblocks-cw-unified.service';
+import { FireblocksCwRegistryService } from './fireblocks-cw-registry.service';
 import { AdminAuditModule } from './modules/admin-audit.module';
 import { AdminDestinationsModule } from './modules/admin-destinations.module';
 import { AdminGasOperationsModule } from './modules/admin-gas-operations.module';
@@ -28,12 +28,12 @@ const NON_ADMIN_MODULES = [
 
 @Module({
   imports: [FireblocksCoreModule, ...ADMIN_MODULES, ...NON_ADMIN_MODULES],
-  providers: [FireblocksCwUnifiedService],
+  providers: [FireblocksCwRegistryService],
   exports: [
     FireblocksCoreModule,
-    FireblocksCwUnifiedService,
+    FireblocksCwRegistryService,
     ...ADMIN_MODULES,
     ...NON_ADMIN_MODULES,
   ],
 })
-export class FireblocksCwUnifiedModule {}
+export class FireblocksCwRegistryModule {}

--- a/src/providers/fireblocks/cw/core/fireblocks-cw-registry.service.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-cw-registry.service.ts
@@ -25,7 +25,7 @@ const NON_ADMIN_MODULES: Array<Type> = [
 ];
 
 @Injectable()
-export class FireblocksCwUnifiedService {
+export class FireblocksCwRegistryService {
   getAdminModules(): Array<Type> {
     return [...ADMIN_MODULES];
   }

--- a/src/providers/fireblocks/cw/core/providers/fireblocks-resilience.ts
+++ b/src/providers/fireblocks/cw/core/providers/fireblocks-resilience.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksDomainOutcome } from './fireblocks-error-mapper';
+import { FireblocksDomainOutcome } from '../../infrastructure/persistence/relational/mappers/fireblocks-error.mapper';
 
 @Injectable()
 export class FireblocksResilience {

--- a/src/providers/fireblocks/cw/core/services/admin-withdrawals.service.ts
+++ b/src/providers/fireblocks/cw/core/services/admin-withdrawals.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { FireblocksErrorMapper } from '../providers/fireblocks-error-mapper';
+import { FireblocksErrorMapper } from '../../infrastructure/persistence/relational/mappers/fireblocks-error.mapper';
 
 @Injectable()
 export class AdminWithdrawalsService {

--- a/src/providers/fireblocks/cw/core/services/cw-transfers.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-transfers.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { FireblocksClientProvider } from '../providers/fireblocks-client.provider';
-import { FireblocksErrorMapper } from '../providers/fireblocks-error-mapper';
+import { FireblocksErrorMapper } from '../../infrastructure/persistence/relational/mappers/fireblocks-error.mapper';
 import { FireblocksResilience } from '../providers/fireblocks-resilience';
 
 export interface TransferCommand {

--- a/src/providers/fireblocks/cw/fireblocks-cw.helper.ts
+++ b/src/providers/fireblocks/cw/fireblocks-cw.helper.ts
@@ -1,0 +1,14 @@
+export const isRateLimitError = (error: any): boolean =>
+  Boolean(error?.response?.status === 429);
+
+export const isPolicyRejection = (error: any): boolean =>
+  error?.response?.data?.status === 'REJECTED' ||
+  error?.response?.data?.code === 'POLICY_REJECTION';
+
+export const isPendingPolicy = (error: any): boolean =>
+  error?.response?.data?.status === 'PENDING_AUTHORIZATION';
+
+export const isInvalidRequest = (error: any): boolean => {
+  const status = error?.response?.status;
+  return status === 400 || status === 404 || status === 422;
+};

--- a/src/providers/fireblocks/cw/fireblocks-cw.module.ts
+++ b/src/providers/fireblocks/cw/fireblocks-cw.module.ts
@@ -1,15 +1,15 @@
 import { Module } from '@nestjs/common';
-import { FireblocksCwUnifiedModule } from './core/fireblocks-cw-unified.module';
+import { FireblocksCwRegistryModule } from './core/fireblocks-cw-registry.module';
 import { FireblocksWebhookModule } from './webhook/fireblocks-webhook.module';
 
 @Module({
   imports: [
     FireblocksWebhookModule,
-    FireblocksCwUnifiedModule,
+    FireblocksCwRegistryModule,
   ],
   exports: [
     FireblocksWebhookModule,
-    FireblocksCwUnifiedModule,
+    FireblocksCwRegistryModule,
   ],
 })
 export class FireblocksCwModule {}


### PR DESCRIPTION
## Summary
- rename the Fireblocks CW registry module and service to remove the unified naming
- relocate the Fireblocks error mapper under an infrastructure/relational mappers path and share helper utilities
- add helper functions for Fireblocks CW error detection

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693944ebf744832a991b527997a96757)