### PR TITLE
Refactor Fireblocks admin dependencies

### DIFF
--- a/src/providers/fireblocks/cw/core/admin/base/abstract-cw.service.ts
+++ b/src/providers/fireblocks/cw/core/admin/base/abstract-cw.service.ts
@@ -1,15 +1,17 @@
+import { ConfigService } from '@nestjs/config';
+import { AllConfigType } from '../../../../../../config/config.type';
 import { AbstractAdminService } from './abstract-admin.service';
-import { FireblocksCwService } from '../../../fireblocks-cw.service';
 
 export abstract class AbstractCwService extends AbstractAdminService {
   protected constructor(
     context: string,
-    protected readonly client: FireblocksCwService,
+    protected readonly configService: ConfigService<AllConfigType>,
   ) {
     super(context);
   }
 
   protected debugBasePath(): void {
-    this.debug(`Using basePath ${this.client.getOptions().basePath}`);
+    const basePath = this.configService.get('fireblocks.basePath', { infer: true }) ?? '';
+    this.debug(`Using basePath ${basePath}`);
   }
 }

--- a/src/providers/fireblocks/cw/core/admin/services/admin-audit.service.ts
+++ b/src/providers/fireblocks/cw/core/admin/services/admin-audit.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AllConfigType } from '../../../../../../config/config.type';
 import { AbstractCwService } from '../base/abstract-cw.service';
-import { FireblocksCwService } from '../../../fireblocks-cw.service';
 
 @Injectable()
 export class AdminAuditService extends AbstractCwService {
-  constructor(client: FireblocksCwService) {
-    super(AdminAuditService.name, client);
+  constructor(configService: ConfigService<AllConfigType>) {
+    super(AdminAuditService.name, configService);
   }
 
   async getLogs(): Promise<void> {

--- a/src/providers/fireblocks/cw/core/admin/services/admin-destinations.service.ts
+++ b/src/providers/fireblocks/cw/core/admin/services/admin-destinations.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AllConfigType } from '../../../../../../config/config.type';
 import { AbstractCwService } from '../base/abstract-cw.service';
-import { FireblocksCwService } from '../../../fireblocks-cw.service';
 
 @Injectable()
 export class AdminDestinationsService extends AbstractCwService {
-  constructor(client: FireblocksCwService) {
-    super(AdminDestinationsService.name, client);
+  constructor(configService: ConfigService<AllConfigType>) {
+    super(AdminDestinationsService.name, configService);
   }
 
   async addDestination(name: string, address: string): Promise<void> {

--- a/src/providers/fireblocks/cw/core/admin/services/admin-gas-operations.service.ts
+++ b/src/providers/fireblocks/cw/core/admin/services/admin-gas-operations.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AllConfigType } from '../../../../../../config/config.type';
 import { AbstractCwService } from '../base/abstract-cw.service';
-import { FireblocksCwService } from '../../../fireblocks-cw.service';
 
 @Injectable()
 export class AdminGasOperationsService extends AbstractCwService {
-  constructor(client: FireblocksCwService) {
-    super(AdminGasOperationsService.name, client);
+  constructor(configService: ConfigService<AllConfigType>) {
+    super(AdminGasOperationsService.name, configService);
   }
 
   async allocateGas(vaultAccountId: string, amount: string): Promise<void> {

--- a/src/providers/fireblocks/cw/core/base/cw-client.service.ts
+++ b/src/providers/fireblocks/cw/core/base/cw-client.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { FireblocksCwService } from '../../fireblocks-cw.service';
 import { CwDepositService } from '../services/cw-deposit.service';
 import { CwPortfolioService } from '../services/cw-portfolio.service';
 import { CwTransactionsService } from '../services/cw-transactions.service';
@@ -12,6 +11,5 @@ export class CwClientService {
     public readonly deposits: CwDepositService,
     public readonly transfers: CwTransfersService,
     public readonly transactions: CwTransactionsService,
-    public readonly clientConfig: FireblocksCwService,
   ) {}
 }

--- a/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
@@ -7,6 +7,11 @@ import { FireblocksResilienceService } from './shared/fireblocks-resilience.serv
 @Module({
   imports: [ConfigModule],
   providers: [FireblocksCwService, FireblocksErrorMapper, FireblocksResilienceService],
-  exports: [FireblocksCwService, FireblocksErrorMapper, FireblocksResilienceService],
+  exports: [
+    ConfigModule,
+    FireblocksCwService,
+    FireblocksErrorMapper,
+    FireblocksResilienceService,
+  ],
 })
 export class FireblocksCoreModule {}


### PR DESCRIPTION
## Summary
- replace FireblocksCwService dependencies in admin CW services with ConfigService to avoid circular imports
- export ConfigModule from FireblocksCoreModule so configuration access is available to dependent modules
- simplify CwClientService by removing unused FireblocksCwService dependency

## Testing
- npm test *(fails: jest not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399f6f7ce0832aad31cabba7811be7)