### PR TITLE
Fix Fireblocks CW dependency resolution when disabled

### DIFF
--- a/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
+++ b/src/providers/fireblocks/cw/core/fireblocks-core.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { FireblocksCwService } from '../fireblocks-cw.service';
 import { FireblocksErrorMapper } from '../infrastructure/persistence/relational/mappers/fireblocks-error.mapper';
 import { FireblocksResilienceService } from './shared/fireblocks-resilience.service';
 
+@Global()
 @Module({
   imports: [ConfigModule],
   providers: [FireblocksCwService, FireblocksErrorMapper, FireblocksResilienceService],

--- a/src/providers/fireblocks/cw/core/modules/cw-deposit.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-deposit.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { FireblocksCoreModule } from '../fireblocks-core.module';
+import { FireblocksCwService } from '../../fireblocks-cw.service';
 import { CwDepositService } from '../services/cw-deposit.service';
 
 @Module({
-  imports: [FireblocksCoreModule],
-  providers: [CwDepositService],
+  imports: [ConfigModule, FireblocksCoreModule],
+  providers: [CwDepositService, FireblocksCwService],
   exports: [CwDepositService],
 })
 export class CwDepositModule {}


### PR DESCRIPTION
## Summary
- add safe option resolution for Fireblocks CW service to allow disabled configs
- mark Fireblocks core module as global and ensure deposit module provides required services

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a280eb58832ab7d027f96aa0ec85)