### PR TITLE
Ensure config module loads before Fireblocks modules

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -58,16 +58,6 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
 
 @Module({
   imports: [
-    FireblocksNcwWalletsModule,
-    FireblocksCwWalletsModule,
-    FireblocksCwModule,
-    WalletsModule,
-    MessagesModule,
-    PassphrasesModule,
-    AddressBooksModule,
-    DevicesModule,
-    NotificationsModule,
-    WebhooksModule,
     ConfigModule.forRoot({
       isGlobal: true,
       load: [
@@ -88,6 +78,16 @@ const infrastructureDatabaseModule = TypeOrmModule.forRootAsync({
       ],
       envFilePath: ['.env'],
     }),
+    FireblocksNcwWalletsModule,
+    FireblocksCwWalletsModule,
+    FireblocksCwModule,
+    WalletsModule,
+    MessagesModule,
+    PassphrasesModule,
+    AddressBooksModule,
+    DevicesModule,
+    NotificationsModule,
+    WebhooksModule,
     infrastructureDatabaseModule,
     I18nModule.forRootAsync({
       useFactory: (configService: ConfigService<AllConfigType>) => ({


### PR DESCRIPTION
## Summary
- move ConfigModule.forRoot to the top of AppModule imports so configuration providers are available to Fireblocks modules

## Testing
- not run (environment missing project dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a6f4dc98832aaedd70a699bfb52b)