### PR TITLE
Fix CwPortfolio module dependency resolution

### DIFF
--- a/src/providers/fireblocks/cw/core/modules/cw-portfolio.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-portfolio.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { FireblocksCoreModule } from '../fireblocks-core.module';
 import { CwPortfolioService } from '../services/cw-portfolio.service';
 
 @Module({
-  imports: [FireblocksCoreModule],
+  imports: [forwardRef(() => FireblocksCoreModule)],
   providers: [CwPortfolioService],
   exports: [CwPortfolioService],
 })

--- a/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
@@ -1,11 +1,14 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
 import { FireblocksCwService } from '../../fireblocks-cw.service';
 
 @Injectable()
 export class CwPortfolioService {
   private readonly logger = new Logger(CwPortfolioService.name);
 
-  constructor(private readonly client: FireblocksCwService) {}
+  constructor(
+    @Inject(forwardRef(() => FireblocksCwService))
+    private readonly client: FireblocksCwService,
+  ) {}
 
   async getBalances(vaultAccountId: string): Promise<void> {
     this.logger.log(`Fetch balances for vault ${vaultAccountId}`);


### PR DESCRIPTION
## Summary
- ensure `CwPortfolioModule` imports `FireblocksCoreModule` via `forwardRef`
- inject `FireblocksCwService` into `CwPortfolioService` using a forward reference to resolve the dependency

## Testing
- npx ts-node -e "import { Test } from '@nestjs/testing'; import { CwPortfolioModule } from './src/providers/fireblocks/cw/core/modules/cw-portfolio.module'; async function run(){ await Test.createTestingModule({imports:[CwPortfolioModule]}).compile(); console.log('ok'); } run();"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a455ce1b0832a8ca379cf477b5158)