### PR TITLE
Add forwardRef for FireblocksCoreModule in CW transfers module

### DIFF
--- a/src/providers/fireblocks/cw/core/modules/cw-transfers.module.ts
+++ b/src/providers/fireblocks/cw/core/modules/cw-transfers.module.ts
@@ -1,9 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { FireblocksCoreModule } from '../fireblocks-core.module';
 import { CwTransfersService } from '../services/cw-transfers.service';
 
 @Module({
-  imports: [FireblocksCoreModule],
+  imports: [forwardRef(() => FireblocksCoreModule)],
   providers: [CwTransfersService],
   exports: [CwTransfersService],
 })


### PR DESCRIPTION
## Summary
- use forwardRef when importing FireblocksCoreModule into CwTransfersModule
- ensure FireblocksCoreModule providers are resolvable when wiring CwTransfersService

## Testing
- not run (dependencies not installed in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a480d4974832a894904daae06f931)