### PR TITLE
Use defaults for Fireblocks config lookups

### DIFF
--- a/src/providers/fireblocks/cw/core/base/abstract-cw.service.ts
+++ b/src/providers/fireblocks/cw/core/base/abstract-cw.service.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AllConfigType } from '../../../../../config/config.type';
+import { FIREBLOCKS_ENV_TYPE } from '../../types/fireblocks-const.type';
 
 export abstract class AbstractCwService {
   protected readonly logger: Logger;
@@ -26,9 +27,9 @@ export abstract class AbstractCwService {
       return;
     }
 
-    const envType =
-      this.configService.get('fireblocks.envType', { infer: true }) ??
-      'unknown';
+    const envType = this.configService.get('fireblocks.envType', FIREBLOCKS_ENV_TYPE, {
+      infer: true,
+    });
     this.debug(`Using environment ${envType}`);
   }
 }

--- a/src/providers/fireblocks/cw/fireblocks-cw.service.ts
+++ b/src/providers/fireblocks/cw/fireblocks-cw.service.ts
@@ -4,9 +4,12 @@ import { ModuleRef } from '@nestjs/core';
 import { Fireblocks } from '@fireblocks/ts-sdk';
 import { AllConfigType } from '../../../config/config.type';
 import { FireblocksClientOptions } from './types/fireblocks-base.type';
-import { FireblocksEnvironmentType } from './types/fireblocks-enum.type';
 import { CwAdminService } from './core/base/cw-admin.service';
 import { CwClientService } from './core/base/cw-client.service';
+import {
+  FIREBLOCKS_ENABLE,
+  FIREBLOCKS_ENV_TYPE,
+} from './types/fireblocks-const.type';
 
 @Injectable()
 export class FireblocksCwService implements OnModuleInit, OnModuleDestroy {
@@ -115,10 +118,12 @@ export class FireblocksCwService implements OnModuleInit, OnModuleDestroy {
   }
 
   private resolveOptions(): FireblocksClientOptions {
-    const enable = this.configService.get('fireblocks.enable', { infer: true }) ?? false;
-    const envType =
-      this.configService.get('fireblocks.envType', { infer: true }) ??
-      FireblocksEnvironmentType.SANDBOX;
+    const enable = this.configService.get('fireblocks.enable', FIREBLOCKS_ENABLE, {
+      infer: true,
+    });
+    const envType = this.configService.get('fireblocks.envType', FIREBLOCKS_ENV_TYPE, {
+      infer: true,
+    });
 
     if (!enable) {
       return {


### PR DESCRIPTION
## Summary
- provide default Fireblocks enable and environment values when reading configuration
- ensure Fireblocks base services log environment using configured defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a5ecb1bdc832a85c24ec35e829476)