### PR TITLE
fix: align Fireblocks CW SDK mappings

### DIFF
--- a/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
+++ b/src/providers/fireblocks/cw/core/services/cw-portfolio.service.ts
@@ -78,12 +78,11 @@ export class CwPortfolioService {
     this.ensureEnabled();
     const sdk = this.client.getSdk();
     const response = await sdk.blockchainsAssets.listAssets({
-      limit,
-      before: cursor?.before,
-      after: cursor?.after,
+      pageSize: limit,
+      pageCursor: cursor?.before ?? cursor?.after,
     });
 
-    return (response.data as ListAssetsResponse).assets.map((asset: Asset) =>
+    return (response.data as ListAssetsResponse).data.map((asset: Asset) =>
       FireblocksCwMapper.toAssetMetadataDto(asset),
     );
   }
@@ -91,7 +90,7 @@ export class CwPortfolioService {
   async getAsset(assetId: string): Promise<FireblocksAssetMetadataDto> {
     this.ensureEnabled();
     const sdk = this.client.getSdk();
-    const response = await sdk.blockchainsAssets.getAsset({ assetId });
+    const response = await sdk.blockchainsAssets.getAsset({ id: assetId });
     return FireblocksCwMapper.toAssetMetadataDto(response.data as Asset);
   }
 
@@ -99,7 +98,7 @@ export class CwPortfolioService {
     this.ensureEnabled();
     const sdk = this.client.getSdk();
     const response = await sdk.blockchainsAssets.listBlockchains();
-    return (response.data as ListBlockchainsResponse).blockchains.map(
+    return (response.data as ListBlockchainsResponse).data.map(
       (blockchain: BlockchainResponse) => FireblocksCwMapper.toBlockchainDto(blockchain),
     );
   }
@@ -108,7 +107,7 @@ export class CwPortfolioService {
     this.ensureEnabled();
     const sdk = this.client.getSdk();
     const response = await sdk.blockchainsAssets.getBlockchain({
-      blockchainId,
+      id: blockchainId,
     });
 
     return FireblocksCwMapper.toBlockchainDto(response.data as BlockchainResponse);

--- a/src/providers/fireblocks/cw/helpers/fireblocks-cw.mapper.ts
+++ b/src/providers/fireblocks/cw/helpers/fireblocks-cw.mapper.ts
@@ -25,12 +25,12 @@ export class FireblocksCwMapper {
     return GroupPlainToInstance(
       FireblocksVaultAssetDto,
       {
-        id: asset.id ?? asset.assetId,
+        id: asset.id,
         total: asset.total as string | undefined,
         available: asset.available as string | undefined,
         lockedAmount: asset.lockedAmount as string | undefined,
         pending: asset.pending as string | undefined,
-        totalStaked: asset.totalStaked as string | undefined,
+        totalStaked: asset.staked as string | undefined,
         balance: asset.balance as string | undefined,
       },
       roles,
@@ -64,8 +64,7 @@ export class FireblocksCwMapper {
       FireblocksDepositAddressDto,
       {
         address: address?.address,
-        tag: address?.tag ?? address?.legacyAddress?.tag,
-        description: address?.description,
+        tag: address?.tag,
         customerRefId: (address as { customerRefId?: string }).customerRefId,
       },
       roles,
@@ -102,9 +101,9 @@ export class FireblocksCwMapper {
       FireblocksAssetMetadataDto,
       {
         id: asset.id,
-        name: asset.name,
-        symbol: asset.symbol,
-        type: asset.type,
+        name: asset.displayName,
+        symbol: asset.onchain?.symbol ?? asset.displaySymbol,
+        type: asset.assetClass,
         hasTag: (asset as { hasTag?: boolean }).hasTag,
         blockchainId: (asset as { blockchainId?: string }).blockchainId,
         isSupported: (asset as { isSupported?: boolean }).isSupported,
@@ -121,10 +120,10 @@ export class FireblocksCwMapper {
       FireblocksBlockchainDto,
       {
         id: blockchain.id,
-        name: blockchain.name,
-        description: blockchain.description,
-        nativeAsset: blockchain.nativeAsset,
-        status: blockchain.status,
+        name: blockchain.displayName,
+        description: (blockchain.metadata as { description?: string })?.description,
+        nativeAsset: blockchain.nativeAssetId,
+        status: (blockchain.onchain as { status?: string })?.status,
       },
       roles,
     );

--- a/src/providers/fireblocks/cw/infrastructure/persistence/relational/mappers/fireblocks-error.mapper.ts
+++ b/src/providers/fireblocks/cw/infrastructure/persistence/relational/mappers/fireblocks-error.mapper.ts
@@ -2,11 +2,11 @@ import {
   BadRequestException,
   ForbiddenException,
   HttpException,
+  HttpStatus,
   Injectable,
   InternalServerErrorException,
   Logger,
   ServiceUnavailableException,
-  TooManyRequestsException,
 } from '@nestjs/common';
 import {
   isInvalidRequest,
@@ -39,7 +39,7 @@ export class FireblocksErrorMapper {
 
     switch (outcome) {
       case 'RATE_LIMITED':
-        return new TooManyRequestsException(message);
+        return new HttpException(message, HttpStatus.TOO_MANY_REQUESTS);
       case 'REQUEST_REJECTED_POLICY':
         return new ForbiddenException(message);
       case 'INVALID_REQUEST':


### PR DESCRIPTION
## Summary
- update Fireblocks CW portfolio service to use new SDK request parameters and response shapes
- refresh CW mappers to handle updated asset, blockchain, and address fields from the latest SDK
- replace deprecated rate limit exception with a generic HTTP exception using status 429

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a969a53d4832a99183f0ec4b1801f)