### PR TITLE
Add helper to provision Fireblocks custodial vaults for users

### DIFF
--- a/src/providers/fireblocks/cw/core/base/cw-client.service.ts
+++ b/src/providers/fireblocks/cw/core/base/cw-client.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { FireblocksCustodialWalletDto } from '../../dto/fireblocks-wallet.dto';
-import { CwDepositService, CreateCustodialWalletCommand } from '../services/cw-deposit.service';
+import {
+  CwDepositService,
+  CreateVaultWalletRequest,
+  FireblocksUserIdentity,
+} from '../services/cw-deposit.service';
 import { CwPortfolioService } from '../services/cw-portfolio.service';
 import { CwTransactionsService } from '../services/cw-transactions.service';
 import { CwTransfersService } from '../services/cw-transfers.service';
@@ -15,8 +19,21 @@ export class CwClientService {
   ) {}
 
   async createWallet(
-    command: CreateCustodialWalletCommand,
+    command: CreateVaultWalletRequest,
   ): Promise<FireblocksCustodialWalletDto> {
     return this.deposits.createCustodialWallet(command);
+  }
+
+  async ensureUserWallet(
+    user: FireblocksUserIdentity,
+    assetId: string,
+    options?: {
+      hiddenOnUI?: boolean;
+      autoFuel?: boolean;
+      addressDescription?: string;
+      idempotencyKey?: string;
+    },
+  ): Promise<FireblocksCustodialWalletDto> {
+    return this.deposits.ensureUserCustodialWallet(user, assetId, options);
   }
 }


### PR DESCRIPTION
## Summary
- rename the custodial wallet creation request type to `CreateVaultWalletRequest` for clarity
- update the Fireblocks CW client to use the clearer request name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9fb5edc0832aa9c9e4931ff00159)