### PR TITLE
Handle missing secret in sync-private workflow

### DIFF
--- a/.github/workflows/sync-private.yml
+++ b/.github/workflows/sync-private.yml
@@ -7,24 +7,41 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    env:
+      TARGET_REPO_PAT: ${{ secrets.PRIVATE_VERO_REPO_TOKEN }}
     steps:
+      - name: Check for target PAT
+        id: secret-check
+        run: |
+          if [ -z "${TARGET_REPO_PAT}" ]; then
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Mirror skipped::PRIVATE_VERO_REPO_TOKEN is not set; skipping sync. This is expected on forks or environments without access to the secret."
+            exit 0
+          fi
+          echo "missing=false" >> "$GITHUB_OUTPUT"
+
       # 1. Check out latest public main
       - uses: actions/checkout@v4
+        if: steps.secret-check.outputs.missing == 'false'
         with:
           fetch-depth: 0
 
       # 2. Rewrite commit author and remote info to hide origin
       - name: Prepare anonymous mirror
-        env:
-          TARGET_REPO_PAT: ${{ secrets.PRIVATE_VERO_REPO_TOKEN }}
+        if: steps.secret-check.outputs.missing == 'false'
         run: |
           git config user.name  "build-sync"
           git config user.email "build-sync@users.noreply.github.com"
           git remote remove origin
           git remote add target "https://x-access-token:${TARGET_REPO_PAT}@github.com/Metapolitanltd/VaultBackend.git"
 
+      - name: Verify access to target repository
+        if: steps.secret-check.outputs.missing == 'false'
+        run: git ls-remote --exit-code target
+
       # 3. Push as plain code snapshot
       - name: Push to private repository
+        if: steps.secret-check.outputs.missing == 'false'
         run: |
           # Create a detached copy of main tree as a new commit
           git switch --detach


### PR DESCRIPTION
## Summary
- skip the mirror job when PRIVATE_VERO_REPO_TOKEN is unavailable, emitting a notice instead of failing
- gate checkout/push steps behind the secret check and verify access to the target repository before pushing

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694289296814832a87f002e2de2f1cbc)