### PR TITLE
feat: add internal events outbox module

### DIFF
--- a/src/common/internal-events/entities/internal-event-outbox.entity.ts
+++ b/src/common/internal-events/entities/internal-event-outbox.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({
+  name: 'event_outbox',
+})
+export class InternalEventOutboxEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: String })
+  eventType: string;
+
+  @Column({ type: 'jsonb' })
+  payload: Record<string, unknown>;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Index()
+  @Column({ type: 'timestamptz', nullable: true })
+  publishedAt: Date | null;
+}

--- a/src/common/internal-events/internal-event-handler.decorator.ts
+++ b/src/common/internal-events/internal-event-handler.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { INTERNAL_EVENT_HANDLER_METADATA } from './internal-events.constants';
+
+export const InternalEventHandler = (eventType: string) =>
+  SetMetadata(INTERNAL_EVENT_HANDLER_METADATA, eventType);

--- a/src/common/internal-events/internal-events.constants.ts
+++ b/src/common/internal-events/internal-events.constants.ts
@@ -1,0 +1,2 @@
+export const INTERNAL_EVENT_HANDLER_METADATA = 'internal-event-handler';
+export const INTERNAL_EVENTS_OPTIONS = Symbol('INTERNAL_EVENTS_OPTIONS');

--- a/src/common/internal-events/internal-events.consumer.ts
+++ b/src/common/internal-events/internal-events.consumer.ts
@@ -1,0 +1,237 @@
+import { Inject, Injectable } from '@nestjs/common';
+import os from 'os';
+import { InternalEventsRedisService } from './internal-events.redis.service';
+import { InternalEventsRegistry } from './internal-events.registry';
+import { INTERNAL_EVENTS_OPTIONS } from './internal-events.constants';
+import { InternalEventMessage, InternalEventsModuleOptions } from './internal-events.types';
+import { LoggerService } from '../logger/logger.service';
+
+@Injectable()
+export class InternalEventsConsumer {
+  private running = false;
+  private consumerName = '';
+  private lastClaimAt = 0;
+
+  constructor(
+    private readonly redisService: InternalEventsRedisService,
+    private readonly registry: InternalEventsRegistry,
+    private readonly loggerService: LoggerService,
+    @Inject(INTERNAL_EVENTS_OPTIONS)
+    private readonly options: InternalEventsModuleOptions,
+  ) {}
+
+  async onModuleInit() {
+    const redis = this.redisService.getClient();
+    const suffix = `${os.hostname()}-${process.pid}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    this.consumerName = `${this.options.serviceName}-${suffix}`;
+
+    await this.ensureStreamGroup();
+
+    this.running = true;
+    void this.consumeLoop();
+  }
+
+  onModuleDestroy() {
+    this.running = false;
+  }
+
+  private async ensureStreamGroup() {
+    const redis = this.redisService.getClient();
+
+    try {
+      await (redis as any).xgroup(
+        'CREATE',
+        this.options.streamName,
+        this.options.serviceName,
+        '$',
+        'MKSTREAM',
+      );
+    } catch (error) {
+      const message = (error as Error)?.message ?? String(error);
+      if (!message.includes('BUSYGROUP')) {
+        throw error;
+      }
+    }
+  }
+
+  private async consumeLoop() {
+    const redis = this.redisService.getClient();
+
+    while (this.running) {
+      try {
+        await this.maybeClaimPending();
+
+        const response = await (redis as any).xreadgroup(
+          'GROUP',
+          this.options.serviceName,
+          this.consumerName,
+          'BLOCK',
+          this.options.consumerBlockMs,
+          'COUNT',
+          this.options.consumerCount,
+          'STREAMS',
+          this.options.streamName,
+          '>',
+        );
+
+        if (!response) continue;
+
+        for (const [, entries] of response as [
+          string,
+          [string, string[]][],
+        ][]) {
+          for (const [id, fields] of entries) {
+            await this.processMessage(id, this.parseFields(fields));
+          }
+        }
+      } catch (error) {
+        const reason = (error as Error)?.message ?? String(error);
+        this.loggerService.warn(
+          `InternalEventsConsumer loop failed: ${reason}`,
+          InternalEventsConsumer.name,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+  }
+
+  private async maybeClaimPending() {
+    const now = Date.now();
+    if (now - this.lastClaimAt < this.options.pendingClaimAfterMs) return;
+    this.lastClaimAt = now;
+
+    const redis = this.redisService.getClient();
+
+    try {
+      const response = await (redis as any).xautoclaim(
+        this.options.streamName,
+        this.options.serviceName,
+        this.consumerName,
+        this.options.pendingClaimAfterMs,
+        '0-0',
+        'COUNT',
+        this.options.consumerCount,
+      );
+
+      if (!response) return;
+
+      const [, entries] = response as [string, [string, string[]][]];
+
+      for (const [id, fields] of entries) {
+        await this.processMessage(id, this.parseFields(fields));
+      }
+    } catch (error) {
+      const reason = (error as Error)?.message ?? String(error);
+      this.loggerService.warn(
+        `InternalEventsConsumer pending claim failed: ${reason}`,
+        InternalEventsConsumer.name,
+      );
+    }
+  }
+
+  private parseFields(fields: string[]): Record<string, string> {
+    const data: Record<string, string> = {};
+    for (let i = 0; i < fields.length; i += 2) {
+      data[fields[i]] = fields[i + 1];
+    }
+    return data;
+  }
+
+  private async processMessage(id: string, fields: Record<string, string>) {
+    const redis = this.redisService.getClient();
+
+    const message: InternalEventMessage = {
+      eventId: fields.eventId,
+      eventType: fields.eventType,
+      payload: fields.payload ? JSON.parse(fields.payload) : {},
+      occurredAt: fields.occurredAt,
+    };
+
+    const idempotencyKey = `processed:${this.options.serviceName}:${message.eventId}`;
+
+    const setResult = await redis.set(
+      idempotencyKey,
+      '1',
+      'NX',
+      'EX',
+      this.options.idempotencyTtlSeconds,
+    );
+
+    if (!setResult) {
+      await (redis as any).xack(
+        this.options.streamName,
+        this.options.serviceName,
+        id,
+      );
+      return;
+    }
+
+    try {
+      const handlers = this.registry.getHandlers(message.eventType);
+      if (!handlers.length) {
+        this.loggerService.warn(
+          `No handler for internal event: ${message.eventType}`,
+          InternalEventsConsumer.name,
+        );
+      }
+
+      for (const handler of handlers) {
+        await handler.handle(message);
+      }
+
+      await (redis as any).xack(
+        this.options.streamName,
+        this.options.serviceName,
+        id,
+      );
+    } catch (error) {
+      await redis.del(idempotencyKey);
+      await this.handleFailure(id, message, error as Error);
+    }
+  }
+
+  private async handleFailure(
+    id: string,
+    message: InternalEventMessage,
+    error: Error,
+  ) {
+    const redis = this.redisService.getClient();
+    const retryKey = `internal-events:retries:${this.options.serviceName}:${id}`;
+    const retries = await redis.incr(retryKey);
+    await redis.expire(retryKey, this.options.idempotencyTtlSeconds);
+
+    if (retries < this.options.maxRetries) {
+      this.loggerService.warn(
+        `Internal event ${message.eventType} failed (attempt ${retries}): ${error.message}`,
+        InternalEventsConsumer.name,
+      );
+      return;
+    }
+
+    if (this.options.dlqStreamName) {
+      await (redis as any).xadd(
+        this.options.dlqStreamName,
+        '*',
+        'eventId',
+        message.eventId,
+        'eventType',
+        message.eventType,
+        'payload',
+        JSON.stringify(message.payload ?? {}),
+        'occurredAt',
+        message.occurredAt,
+        'error',
+        error.message,
+      );
+    }
+
+    await (redis as any).xack(
+      this.options.streamName,
+      this.options.serviceName,
+      id,
+    );
+    await redis.del(retryKey);
+  }
+}

--- a/src/common/internal-events/internal-events.dispatcher.ts
+++ b/src/common/internal-events/internal-events.dispatcher.ts
@@ -1,0 +1,112 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { InternalEventOutboxEntity } from './entities/internal-event-outbox.entity';
+import { InternalEventsRedisService } from './internal-events.redis.service';
+import { INTERNAL_EVENTS_OPTIONS } from './internal-events.constants';
+import { InternalEventsModuleOptions } from './internal-events.types';
+import { LoggerService } from '../logger/logger.service';
+
+@Injectable()
+export class InternalEventsDispatcher {
+  private interval: NodeJS.Timeout | null = null;
+  private lastCleanupAt = 0;
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly redisService: InternalEventsRedisService,
+    private readonly loggerService: LoggerService,
+    @Inject(INTERNAL_EVENTS_OPTIONS)
+    private readonly options: InternalEventsModuleOptions,
+  ) {}
+
+  onModuleInit() {
+    this.interval = setInterval(() => {
+      void this.dispatchOnce();
+    }, this.options.dispatchIntervalMs);
+  }
+
+  onModuleDestroy() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  private async dispatchOnce() {
+    const redis = this.redisService.getClient();
+
+    try {
+      const outboxRows = await this.dataSource.transaction(async (manager) => {
+        return manager
+          .createQueryBuilder(InternalEventOutboxEntity, 'outbox')
+          .setLock('pessimistic_write')
+          .setOnLocked('skip_locked')
+          .where('outbox.publishedAt IS NULL')
+          .orderBy('outbox.createdAt', 'ASC')
+          .limit(this.options.dispatchBatchSize)
+          .getMany();
+      });
+
+      if (!outboxRows.length) {
+        await this.maybeCleanup();
+        return;
+      }
+
+      for (const row of outboxRows) {
+        const payload = JSON.stringify(row.payload ?? {});
+        const xaddArgs: (string | number)[] = [this.options.streamName];
+
+        if (this.options.streamTrimMaxLen) {
+          xaddArgs.push('MAXLEN', '~', this.options.streamTrimMaxLen);
+        }
+
+        xaddArgs.push(
+          '*',
+          'eventId',
+          row.id,
+          'eventType',
+          row.eventType,
+          'payload',
+          payload,
+          'occurredAt',
+          row.createdAt.toISOString(),
+        );
+
+        await (redis as any).xadd(...xaddArgs);
+
+        await this.dataSource
+          .createQueryBuilder()
+          .update(InternalEventOutboxEntity)
+          .set({ publishedAt: new Date() })
+          .where('id = :id', { id: row.id })
+          .execute();
+      }
+
+      await this.maybeCleanup();
+    } catch (error) {
+      const reason = (error as Error)?.message ?? String(error);
+      this.loggerService.warn(
+        `InternalEventsDispatcher dispatch failed: ${reason}`,
+        InternalEventsDispatcher.name,
+      );
+    }
+  }
+
+  private async maybeCleanup() {
+    const now = Date.now();
+    const cleanupIntervalMs = 60 * 60 * 1000;
+    if (now - this.lastCleanupAt < cleanupIntervalMs) return;
+    this.lastCleanupAt = now;
+
+    const retentionMs = this.options.outboxRetentionDays * 24 * 60 * 60 * 1000;
+    const cutoff = new Date(Date.now() - retentionMs);
+
+    await this.dataSource
+      .createQueryBuilder()
+      .delete()
+      .from(InternalEventOutboxEntity)
+      .where('publishedAt IS NOT NULL')
+      .andWhere('publishedAt < :cutoff', { cutoff })
+      .execute();
+  }
+}

--- a/src/common/internal-events/internal-events.module.ts
+++ b/src/common/internal-events/internal-events.module.ts
@@ -1,0 +1,41 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DiscoveryModule } from '@nestjs/core';
+import { InternalEventOutboxEntity } from './entities/internal-event-outbox.entity';
+import { InternalEventsService } from './internal-events.service';
+import { InternalEventsDispatcher } from './internal-events.dispatcher';
+import { InternalEventsConsumer } from './internal-events.consumer';
+import { InternalEventsRegistry } from './internal-events.registry';
+import {
+  buildInternalEventsOptions,
+  InternalEventsModuleOptions,
+} from './internal-events.types';
+import { INTERNAL_EVENTS_OPTIONS } from './internal-events.constants';
+import { InternalEventsRedisService } from './internal-events.redis.service';
+
+@Global()
+@Module({})
+export class InternalEventsModule {
+  static forRoot(
+    options: Partial<InternalEventsModuleOptions> = {},
+  ): DynamicModule {
+    const internalEventsOptions = buildInternalEventsOptions(options);
+
+    return {
+      module: InternalEventsModule,
+      imports: [DiscoveryModule, TypeOrmModule.forFeature([InternalEventOutboxEntity])],
+      providers: [
+        {
+          provide: INTERNAL_EVENTS_OPTIONS,
+          useValue: internalEventsOptions,
+        },
+        InternalEventsRedisService,
+        InternalEventsRegistry,
+        InternalEventsService,
+        InternalEventsDispatcher,
+        InternalEventsConsumer,
+      ],
+      exports: [InternalEventsService],
+    };
+  }
+}

--- a/src/common/internal-events/internal-events.redis.service.ts
+++ b/src/common/internal-events/internal-events.redis.service.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import Redis from 'ioredis';
+import { INTERNAL_EVENTS_OPTIONS } from './internal-events.constants';
+import { InternalEventsModuleOptions } from './internal-events.types';
+
+@Injectable()
+export class InternalEventsRedisService implements OnModuleDestroy {
+  private readonly client: Redis;
+
+  constructor(
+    @Inject(INTERNAL_EVENTS_OPTIONS)
+    private readonly options: InternalEventsModuleOptions,
+  ) {
+    const redisUrl = options.redisUrl ?? 'redis://localhost:6379';
+    this.client = new Redis(redisUrl);
+  }
+
+  getClient(): Redis {
+    return this.client;
+  }
+
+  async onModuleDestroy() {
+    await this.client.quit();
+  }
+}

--- a/src/common/internal-events/internal-events.registry.ts
+++ b/src/common/internal-events/internal-events.registry.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DiscoveryService, Reflector } from '@nestjs/core';
+import { INTERNAL_EVENT_HANDLER_METADATA } from './internal-events.constants';
+
+export type InternalEventHandlerInstance = {
+  handle: (event: unknown) => Promise<void> | void;
+};
+
+@Injectable()
+export class InternalEventsRegistry {
+  private readonly logger = new Logger(InternalEventsRegistry.name);
+  private readonly handlers = new Map<string, InternalEventHandlerInstance[]>();
+
+  constructor(
+    private readonly discoveryService: DiscoveryService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  onModuleInit() {
+    const providers = this.discoveryService.getProviders();
+    providers.forEach((wrapper) => {
+      const instance = wrapper.instance as InternalEventHandlerInstance | null;
+      if (!instance) return;
+      const eventType = this.reflector.get<string>(
+        INTERNAL_EVENT_HANDLER_METADATA,
+        instance.constructor,
+      );
+      if (!eventType) return;
+      if (typeof instance.handle !== 'function') {
+        this.logger.warn(
+          `InternalEventHandler missing handle(): ${instance.constructor.name}`,
+        );
+        return;
+      }
+      const list = this.handlers.get(eventType) ?? [];
+      list.push(instance);
+      this.handlers.set(eventType, list);
+    });
+  }
+
+  getHandlers(eventType: string): InternalEventHandlerInstance[] {
+    return this.handlers.get(eventType) ?? [];
+  }
+}

--- a/src/common/internal-events/internal-events.service.ts
+++ b/src/common/internal-events/internal-events.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from 'typeorm';
+import { InternalEventOutboxEntity } from './entities/internal-event-outbox.entity';
+import { InternalEventToEmit } from './internal-events.types';
+
+@Injectable()
+export class InternalEventsService {
+  async emit<TPayload>(
+    manager: EntityManager,
+    event: InternalEventToEmit<TPayload>,
+  ): Promise<InternalEventOutboxEntity> {
+    const outbox = manager.create(InternalEventOutboxEntity, {
+      eventType: event.eventType,
+      payload: event.payload as Record<string, unknown>,
+    });
+    return manager.save(InternalEventOutboxEntity, outbox);
+  }
+}

--- a/src/common/internal-events/internal-events.types.ts
+++ b/src/common/internal-events/internal-events.types.ts
@@ -1,0 +1,52 @@
+export interface InternalEventToEmit<TPayload = unknown> {
+  eventType: string;
+  payload: TPayload;
+}
+
+export interface InternalEventMessage<TPayload = unknown> {
+  eventId: string;
+  eventType: string;
+  payload: TPayload;
+  occurredAt: string;
+}
+
+export interface InternalEventsModuleOptions {
+  serviceName: string;
+  streamName: string;
+  dlqStreamName?: string;
+  redisUrl?: string;
+  dispatchIntervalMs: number;
+  dispatchBatchSize: number;
+  outboxRetentionDays: number;
+  consumerBlockMs: number;
+  consumerCount: number;
+  idempotencyTtlSeconds: number;
+  maxRetries: number;
+  pendingClaimAfterMs: number;
+  streamTrimMaxLen?: number;
+}
+
+export const INTERNAL_EVENTS_DEFAULTS: InternalEventsModuleOptions = {
+  serviceName: process.env.SERVICE_NAME ?? 'default-service',
+  streamName: 'internal.events',
+  dlqStreamName: 'internal.events.dlq',
+  redisUrl: process.env.REDIS_URL,
+  dispatchIntervalMs: 1000,
+  dispatchBatchSize: 100,
+  outboxRetentionDays: 30,
+  consumerBlockMs: 5000,
+  consumerCount: 10,
+  idempotencyTtlSeconds: 60 * 60 * 24,
+  maxRetries: 10,
+  pendingClaimAfterMs: 60_000,
+  streamTrimMaxLen: 1_000_000,
+};
+
+export function buildInternalEventsOptions(
+  overrides: Partial<InternalEventsModuleOptions> = {},
+): InternalEventsModuleOptions {
+  return {
+    ...INTERNAL_EVENTS_DEFAULTS,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a horizontally-safe internal event system that uses a transactional PostgreSQL outbox and Redis Streams for distribution to avoid duplicate handling across instances.
- Ensure exactly-once publishing from the database and exactly-one handling per logical service via Redis consumer groups.
- Deliver an auto-discovered, idempotent handler registration model so handlers require no manual wiring or Redis/SQL commands.

### Description
- Add `InternalEventOutboxEntity` and `InternalEventsService` with `emit` to record events transactionally into the outbox via TypeORM (use `InternalEventsModule.forRoot` to configure).
- Implement a dispatcher `InternalEventsDispatcher` that claims outbox rows with DB row locking, publishes to the Redis Stream (`XADD`), marks `publishedAt`, and runs automatic retention cleanup.
- Add a consumer `InternalEventsConsumer` that creates/uses a consumer group, reads via blocking `XREADGROUP`, enforces idempotency with Redis `SET NX EX` using the `processed:<serviceName>:<eventId>` key, tracks retries, and optionally moves failed messages to a DLQ stream.
- Provide handler discovery and routing via `InternalEventHandler` decorator and `InternalEventsRegistry` that uses Nest `Reflector`, plus `InternalEventsRedisService` for Redis lifecycle and `internal-events` module wiring.

### Testing
- No automated tests were executed as part of this change.
- Manual/interactive validation was not performed in this rollout (no CI results provided).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694928662784832ab2922efc90cd3666)