### PR TITLE
feat(binance): add Binance provider endpoints and config

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,6 +42,8 @@ import { FireblocksCwWalletsModule } from './fireblocks-cw-wallets/fireblocks-cw
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { CmcModule } from './providers/cmc/cmc.module';
 import cmcConfig from './providers/cmc/config/cmc-config';
+import { BinanceModule } from './providers/binance/binance.module';
+import binanceConfig from './providers/binance/config/binance.config';
 import { ProvidersModule } from './providers/providers.module';
 import awsSecretsManagerConfig from './config/aws-secrets-manager.config';
 import fireblocksConfig from './providers/fireblocks/cw/config/fireblocks.config';
@@ -92,6 +94,7 @@ import { CacheModule } from './common/cache/cache.module';
         rabbitmqConfig,
         minioConfig,
         cmcConfig,
+        binanceConfig,
         awsSecretsManagerConfig,
         fireblocksConfig,
         queuedashConfig,
@@ -149,6 +152,7 @@ import { CacheModule } from './common/cache/cache.module';
     CacheModule,
     SocketIoModule,
     CmcModule,
+    BinanceModule,
     ProvidersModule,
   ],
   providers: [RabbitMQService],

--- a/src/config/config.type.ts
+++ b/src/config/config.type.ts
@@ -11,6 +11,7 @@ import { RabbitMQConfig } from 'src/communication/rabbitMQ/config/rabbitmq-confi
 import { MinIOConfig } from '../providers/minio/config/minio-config.type';
 import { SocketIOConfig } from '../communication/socketio/config/socketio-config.type';
 import { CmcConfig } from '../providers/cmc/config/cmc-config.type';
+import { BinanceConfig } from '../providers/binance/config/binance-config.type';
 import { AwsSecretsManagerConfig } from './types/aws-secrets-manager-config.type';
 import { FireblocksConfig } from '../providers/fireblocks/cw/config/fireblocks-config.type';
 import { QueueDashConfig } from '../common/queuedash/config/queuedash-config.type';
@@ -31,6 +32,7 @@ export type AllConfigType = {
   minIO: MinIOConfig;
   socketIO: SocketIOConfig;
   cmc: CmcConfig;
+  binance: BinanceConfig;
   awsSecretsManager: AwsSecretsManagerConfig;
   fireblocks: FireblocksConfig;
   queuedash: QueueDashConfig;

--- a/src/providers/binance/binance.controller.ts
+++ b/src/providers/binance/binance.controller.ts
@@ -1,0 +1,215 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from 'src/roles/roles.guard';
+import { EnableGuard } from 'src/common/guards/service-enabled.guard';
+import { RequireEnabled, RequireServiceReady } from 'src/utils/decorators/service-toggleable.decorators';
+import { BinanceService } from './binance.service';
+import { BinancePriceDto, BinancePriceQueryDto } from './dto/binance-price.dto';
+import { BinanceHistoryQueryDto, BinanceCandleDto } from './dto/binance-klines.dto';
+import {
+  BinanceChartHeaderDto,
+  BinanceChartHeaderQueryDto,
+  BinanceChartMidPriceDto,
+  BinanceChartMidPriceQueryDto,
+  BinanceChartSeriesDto,
+  BinanceChartSeriesQueryDto,
+  BinanceChartSeriesRangeDto,
+  BinanceChartSeriesRangeQueryDto,
+} from './dto/binance-chart.dto';
+import {
+  BinanceSupportedAssetDto,
+  BinanceSupportedAssetsQueryDto,
+} from './dto/binance-account.dto';
+import { BINANCE_PRESET_TO_INTERVAL, BinanceChartPreset } from './types/binance-const.type';
+import { normalizeAssetPair } from './binance.helper';
+
+function normalizeSymbolOrThrow(input: string): string {
+  try {
+    return normalizeAssetPair(input);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Invalid symbol format';
+    throw new BadRequestException(message);
+  }
+}
+
+@ApiBearerAuth()
+@UseGuards(AuthGuard('jwt'), RolesGuard, EnableGuard)
+@RequireEnabled('binance.enable')
+@RequireServiceReady(BinanceService)
+@ApiTags('Binance')
+@Controller({ path: 'binance', version: '1' })
+export class BinanceController {
+  constructor(private readonly service: BinanceService) {}
+
+  @Get('price')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: [BinancePriceDto] })
+  async getLatestPrice(
+    @Query() query: BinancePriceQueryDto,
+  ): Promise<BinancePriceDto[]> {
+    if (!query?.symbols) {
+      throw new BadRequestException('symbols must be provided');
+    }
+    const rawSymbolList = query.symbols.split(',').map((s) => s.trim());
+    if (!rawSymbolList.length) {
+      throw new BadRequestException('No symbols provided');
+    }
+    const live = query.live !== 'false';
+    return this.service.getLatestPrices(rawSymbolList, live);
+  }
+
+  @Get('history')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: [BinanceCandleDto] })
+  async getCandles(
+    @Query() query: BinanceHistoryQueryDto,
+  ): Promise<BinanceCandleDto[]> {
+    const rawSymbol = String(query.symbol || '');
+    if (!rawSymbol) {
+      throw new BadRequestException('symbol must be provided');
+    }
+    const symbol = normalizeSymbolOrThrow(rawSymbol);
+    const interval = query.interval || '1m';
+    const limit = query.limit ? Number(query.limit) : 100;
+    const live = query.live !== 'false';
+    return this.service.getCandlesticks(symbol, interval, limit, live);
+  }
+
+  @Get('supported-assets')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: [BinanceSupportedAssetDto] })
+  async getSupportedAssets(
+    @Query() query: BinanceSupportedAssetsQueryDto,
+  ): Promise<BinanceSupportedAssetDto[]> {
+    return this.service.getSupportedAssets(query.quoteAsset);
+  }
+
+  @Get('chart/header')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: BinanceChartHeaderDto })
+  async getChartHeader(
+    @Query() query: BinanceChartHeaderQueryDto,
+  ): Promise<BinanceChartHeaderDto> {
+    const rawSymbol = String(query.symbol || '');
+    const preset = (query.preset || 'today') as BinanceChartPreset;
+    if (!rawSymbol) {
+      throw new BadRequestException('symbol required');
+    }
+    const symbol = normalizeSymbolOrThrow(rawSymbol);
+    if (!(preset in BINANCE_PRESET_TO_INTERVAL)) {
+      throw new BadRequestException(`invalid preset: ${preset}`);
+    }
+    return this.service.getChartHeader(symbol, preset);
+  }
+
+  @Get('chart/series')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: BinanceChartSeriesDto })
+  async getChartSeries(
+    @Query() query: BinanceChartSeriesQueryDto,
+  ): Promise<BinanceChartSeriesDto> {
+    const rawSymbol = String(query.symbol || '');
+    const preset = (query.preset || 'today') as BinanceChartPreset;
+    const limit = query.limit ? Number(query.limit) : undefined;
+    if (!rawSymbol) {
+      throw new BadRequestException('symbol required');
+    }
+    const symbol = normalizeSymbolOrThrow(rawSymbol);
+    if (!(preset in BINANCE_PRESET_TO_INTERVAL)) {
+      throw new BadRequestException(`invalid preset: ${preset}`);
+    }
+    const { points, interval } = await this.service.getSeriesByPreset(
+      symbol,
+      preset,
+      limit,
+      true,
+    );
+    const base = await this.service.getBaselineOpen(symbol, preset);
+    const baselineOpen = base.baselineOpen ?? null;
+
+    const lastClose = points.length
+      ? Number(points[points.length - 1].close)
+      : NaN;
+    const priceNow = Number.isFinite(lastClose) ? lastClose : NaN;
+    const priceStr = Number.isFinite(priceNow) ? String(priceNow) : null;
+
+    const changePercent =
+      baselineOpen && baselineOpen > 0 && Number.isFinite(priceNow)
+        ? ((priceNow - baselineOpen) / baselineOpen) * 100
+        : null;
+
+    return {
+      symbol,
+      preset,
+      interval,
+      baseline: { open: baselineOpen, time: base.baselineTime },
+      price: priceStr,
+      changePercent,
+      points,
+    };
+  }
+
+  @Get('chart/mid-price')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: [BinanceChartMidPriceDto] })
+  async getChartMidPrice(
+    @Query() query: BinanceChartMidPriceQueryDto,
+  ): Promise<BinanceChartMidPriceDto[]> {
+    if (!query.symbols) {
+      throw new BadRequestException('symbols required');
+    }
+    const symbols = query.symbols
+      .split(',')
+      .map((s) => s.trim().toUpperCase())
+      .filter(Boolean);
+    if (!symbols.length) {
+      throw new BadRequestException('symbols required');
+    }
+    return this.service.getMidPrices(symbols);
+  }
+
+  @Get('chart/series-range')
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({ type: BinanceChartSeriesRangeDto })
+  async getChartSeriesRange(
+    @Query() query: BinanceChartSeriesRangeQueryDto,
+  ): Promise<BinanceChartSeriesRangeDto> {
+    const rawSymbol = String(query.symbol || '');
+    const preset = (query.preset || 'today') as BinanceChartPreset;
+    const startTime = query.startTime ? Number(query.startTime) : undefined;
+    const endTime = query.endTime ? Number(query.endTime) : undefined;
+    const limit = query.limit ? Number(query.limit) : undefined;
+
+    if (!rawSymbol) {
+      throw new BadRequestException('symbol required');
+    }
+    const symbol = normalizeSymbolOrThrow(rawSymbol);
+    if (!(preset in BINANCE_PRESET_TO_INTERVAL)) {
+      throw new BadRequestException(`invalid preset: ${preset}`);
+    }
+
+    const { points, interval } = await this.service.getSeriesByPresetRange(
+      symbol,
+      preset,
+      { startTime, endTime, limit },
+    );
+
+    return {
+      symbol,
+      preset,
+      interval,
+      points,
+      range: { startTime, endTime },
+    };
+  }
+}

--- a/src/providers/binance/binance.helper.ts
+++ b/src/providers/binance/binance.helper.ts
@@ -1,0 +1,121 @@
+import { BinanceChartPreset, BinanceKlineInterval } from './types/binance-const.type';
+
+export function normalizeAssetPair(input: string): string {
+  const cleaned = input.toUpperCase();
+  if (/^[A-Z0-9]+$/.test(cleaned)) {
+    return cleaned;
+  }
+  const regex = /^([A-Z0-9]+?)(?:_[A-Z]+)?_([A-Z0-9]+?)(?:_[A-Z]+)?$/;
+  const match = cleaned.match(regex);
+  if (!match) {
+    throw new Error(`Invalid symbol format: ${input}`);
+  }
+  const [, baseAsset, quoteAsset] = match;
+  return `${baseAsset}${quoteAsset}`;
+}
+
+export function intervalMs(interval: BinanceKlineInterval): number {
+  const m: Record<BinanceKlineInterval, number> = {
+    '1m': 60_000,
+    '3m': 180_000,
+    '5m': 300_000,
+    '15m': 900_000,
+    '30m': 1_800_000,
+    '1h': 3_600_000,
+    '2h': 7_200_000,
+    '4h': 14_400_000,
+    '6h': 21_600_000,
+    '8h': 28_800_000,
+    '12h': 43_200_000,
+    '1d': 86_400_000,
+    '3d': 259_200_000,
+    '1w': 604_800_000,
+    '1M': 2_629_800_000,
+  };
+  return m[interval] ?? 0;
+}
+
+function berlinOffsetMsAt(utcMs: number): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Berlin',
+    timeZoneName: 'shortOffset',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    hour12: false,
+  }).formatToParts(new Date(utcMs));
+
+  const tz = parts.find((p) => p.type === 'timeZoneName')?.value || 'GMT+1';
+  const match = tz.match(/GMT([+-])(\d{1,2})/);
+  if (!match) return 3_600_000;
+  const sign = match[1] === '-' ? -1 : 1;
+  const hours = parseInt(match[2], 10);
+  return sign * hours * 3_600_000;
+}
+
+function berlinWeekday1to7(utcMs: number): number {
+  const wdStr = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Berlin',
+    weekday: 'short',
+  }).format(new Date(utcMs));
+  const map: Record<string, number> = {
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+    Sun: 7,
+  };
+  return map[wdStr] ?? 1;
+}
+
+export function berlinCalendarAnchorStart(preset: BinanceChartPreset): number {
+  const nowUtc = Date.now();
+  const dateParts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Berlin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .format(new Date(nowUtc))
+    .split('-');
+  const [yStr, mStr, dStr] = dateParts;
+  const y = parseInt(yStr, 10);
+  const m = parseInt(mStr, 10);
+  const d = parseInt(dStr, 10);
+
+  let by = y;
+  let bm = m;
+  let bd = d;
+
+  if (preset === 'week') {
+    const wd = berlinWeekday1to7(nowUtc);
+    const daysFromMonday = wd - 1;
+    const todayBerlinUTC0 = Date.UTC(y, m - 1, d, 0, 0, 0);
+    const todayOffset = berlinOffsetMsAt(todayBerlinUTC0);
+    const todayUTC = todayBerlinUTC0 - todayOffset;
+    const mondayUTC = todayUTC - daysFromMonday * 86_400_000;
+    const mondayParts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Berlin',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .format(new Date(mondayUTC))
+      .split('-');
+    by = parseInt(mondayParts[0], 10);
+    bm = parseInt(mondayParts[1], 10);
+    bd = parseInt(mondayParts[2], 10);
+  } else if (preset === 'month') {
+    bd = 1;
+  } else if (preset === 'year') {
+    bm = 1;
+    bd = 1;
+  }
+
+  const candidateUTC0 = Date.UTC(by, bm - 1, bd, 0, 0, 0);
+  const off = berlinOffsetMsAt(candidateUTC0);
+  return candidateUTC0 - off;
+}

--- a/src/providers/binance/binance.module.ts
+++ b/src/providers/binance/binance.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BinanceService } from './binance.service';
+import { BinanceController } from './binance.controller';
+import { EnableGuard } from 'src/common/guards/service-enabled.guard';
+
+@Module({
+  providers: [BinanceService, EnableGuard],
+  controllers: [BinanceController],
+  exports: [BinanceService],
+})
+export class BinanceModule {}

--- a/src/providers/binance/binance.service.ts
+++ b/src/providers/binance/binance.service.ts
@@ -1,0 +1,418 @@
+import {
+  BadRequestException,
+  Injectable,
+  OnModuleInit,
+} from '@nestjs/common';
+import axios, { AxiosInstance } from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { AllConfigType } from '../../config/config.type';
+import { BaseToggleableService } from '../../common/base/base-toggleable.service';
+import {
+  BINANCE_MAX_KLINE_LIMIT,
+  BINANCE_PRESET_TO_INTERVAL,
+  BINANCE_PRESET_WINDOW_MS,
+  BINANCE_VALID_INTERVALS,
+  BinanceChartPreset,
+  BinanceKlineInterval,
+} from './types/binance-const.type';
+import {
+  berlinCalendarAnchorStart,
+  intervalMs,
+  normalizeAssetPair,
+} from './binance.helper';
+import { BinanceCandleDto } from './dto/binance-klines.dto';
+import { BinanceSupportedAssetDto } from './dto/binance-account.dto';
+
+const BINANCE_KLINES_ENDPOINT = '/api/v3/klines';
+const BINANCE_TICKER_PRICE_ENDPOINT = '/api/v3/ticker/price';
+const BINANCE_BOOK_TICKER_ENDPOINT = '/api/v3/ticker/bookTicker';
+const BINANCE_EXCHANGE_INFO_ENDPOINT = '/api/v3/exchangeInfo';
+
+type BinanceKlineRaw = [
+  number,
+  string,
+  string,
+  string,
+  string,
+  string,
+  number,
+  string,
+  number,
+  string,
+  string,
+  string,
+];
+
+type BinanceBookTicker = {
+  symbol: string;
+  bidPrice: string;
+  askPrice: string;
+};
+
+@Injectable()
+export class BinanceService
+  extends BaseToggleableService
+  implements OnModuleInit
+{
+  private readonly http: AxiosInstance;
+
+  constructor(private readonly configService: ConfigService<AllConfigType>) {
+    super(
+      BinanceService.name,
+      configService.get('binance.enable', { infer: true }) ?? false,
+    );
+
+    this.http = axios.create({
+      baseURL:
+        this.configService.get('binance.baseUrl', { infer: true }) ?? undefined,
+      timeout:
+        this.configService.get('binance.requestTimeoutMs', {
+          infer: true,
+        }) ?? undefined,
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (!this.isEnabled) {
+      this.logger.warn('Binance service is DISABLED. Skipping initialization.');
+      return;
+    }
+
+    this.logger.log('Binance service is ENABLED. Ready to handle requests.');
+  }
+
+  async getLatestPrices(symbols: string[], live = true) {
+    this.checkIfEnabled();
+
+    let normalized: string[] = [];
+    try {
+      normalized = symbols.map((s) => normalizeAssetPair(s));
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Invalid symbol format';
+      throw new BadRequestException(message);
+    }
+    if (!normalized.length) {
+      throw new BadRequestException('No symbols provided');
+    }
+
+    try {
+      const response = await this.http.get(BINANCE_TICKER_PRICE_ENDPOINT, {
+        params: {
+          symbols: JSON.stringify(normalized),
+        },
+      });
+      const data = Array.isArray(response.data) ? response.data : [];
+      return data.map((entry: { symbol: string; price: string }) => ({
+        symbol: entry.symbol,
+        price: entry.price ?? null,
+        source: 'rest' as const,
+      }));
+    } catch (error) {
+      if (!live) {
+        throw error;
+      }
+    }
+
+    const result: { symbol: string; price: string | null; source: 'rest' }[] = [];
+
+    for (const symbol of normalized) {
+      try {
+        const response = await this.http.get(BINANCE_TICKER_PRICE_ENDPOINT, {
+          params: { symbol },
+        });
+        result.push({
+          symbol,
+          price: response.data?.price ?? null,
+          source: 'rest',
+        });
+      } catch {
+        result.push({ symbol, price: null, source: 'rest' });
+      }
+    }
+
+    return result;
+  }
+
+  async getCandlesticks(
+    symbol: string,
+    interval: string,
+    limit: number,
+    live = true,
+  ): Promise<BinanceCandleDto[]> {
+    this.checkIfEnabled();
+
+    const resolvedInterval = interval as BinanceKlineInterval;
+    if (!BINANCE_VALID_INTERVALS.includes(resolvedInterval)) {
+      throw new BadRequestException(`Invalid interval: ${interval}`);
+    }
+
+    const lim = Math.min(Math.max(limit, 1), BINANCE_MAX_KLINE_LIMIT);
+    const response = await this.http.get(BINANCE_KLINES_ENDPOINT, {
+      params: { symbol: symbol.toUpperCase(), interval: resolvedInterval, limit: lim },
+    });
+
+    return (response.data as BinanceKlineRaw[]).map((c) => ({
+      openTime: c[0],
+      open: c[1],
+      high: c[2],
+      low: c[3],
+      close: c[4],
+      volume: c[5],
+      closeTime: c[6],
+      closed: Date.now() >= c[6],
+      source: live ? 'rest' : 'rest',
+    }));
+  }
+
+  async getSupportedAssets(quoteAsset?: string): Promise<BinanceSupportedAssetDto[]> {
+    this.checkIfEnabled();
+
+    const defaultQuoteAsset =
+      this.configService.get('binance.defaultQuoteAsset', { infer: true }) ??
+      undefined;
+    const resolvedQuoteAsset = quoteAsset ?? defaultQuoteAsset;
+    const response = await this.http.get(BINANCE_EXCHANGE_INFO_ENDPOINT);
+    const symbols = Array.isArray(response.data?.symbols)
+      ? response.data.symbols
+      : [];
+
+    let tradingSymbols = symbols.filter(
+      (s: any) => s.status === 'TRADING' && s.isSpotTradingAllowed,
+    );
+
+    if (resolvedQuoteAsset) {
+      tradingSymbols = tradingSymbols.filter(
+        (s: any) => s.quoteAsset === resolvedQuoteAsset.toUpperCase(),
+      );
+    }
+
+    return tradingSymbols.map((s: any) => ({
+      symbol: s.symbol,
+      baseAsset: s.baseAsset,
+      quoteAsset: s.quoteAsset,
+    }));
+  }
+
+  async getChartHeader(symbol: string, preset: BinanceChartPreset) {
+    this.checkIfEnabled();
+
+    const upper = symbol.toUpperCase();
+    const interval = BINANCE_PRESET_TO_INTERVAL[preset];
+    const anchorStart = berlinCalendarAnchorStart(preset);
+
+    const baseline = await this.fetchBaselineOpen(upper, interval, anchorStart);
+
+    const midPrices = await this.getMidPrices([upper]);
+    const mid = midPrices?.[0]?.price ? Number(midPrices[0].price) : NaN;
+
+    let priceNow = mid;
+    if (!Number.isFinite(priceNow)) {
+      const series = await this.getSeriesByPreset(upper, preset, 2, false);
+      if (series.points.length) {
+        priceNow = Number(series.points[series.points.length - 1].close);
+      }
+    }
+
+    const changePercent =
+      baseline && baseline > 0 && Number.isFinite(priceNow)
+        ? ((priceNow - baseline) / baseline) * 100
+        : null;
+
+    return {
+      symbol: upper,
+      price: Number.isFinite(priceNow) ? String(priceNow) : null,
+      changePercent,
+      preset,
+      interval,
+    };
+  }
+
+  async getBaselineOpen(
+    symbol: string,
+    preset: BinanceChartPreset,
+  ): Promise<{
+    baselineOpen: number | null;
+    baselineTime: number | null;
+    interval: BinanceKlineInterval;
+  }> {
+    this.checkIfEnabled();
+
+    const interval = BINANCE_PRESET_TO_INTERVAL[preset];
+    const anchorStart = berlinCalendarAnchorStart(preset);
+    const response = await this.http.get(BINANCE_KLINES_ENDPOINT, {
+      params: {
+        symbol: symbol.toUpperCase(),
+        interval,
+        limit: 2,
+        startTime: anchorStart,
+      },
+    });
+
+    const ks = response.data as BinanceKlineRaw[];
+    if (ks.length) {
+      return {
+        baselineOpen: Number(ks[0][1]),
+        baselineTime: ks[0][0],
+        interval,
+      };
+    }
+
+    const series = await this.fetchSeriesRaw(upper, interval, 10);
+    if (series.points.length) {
+      return {
+        baselineOpen: Number(series.points[0].open),
+        baselineTime: series.points[0].openTime,
+        interval,
+      };
+    }
+
+    return { baselineOpen: null, baselineTime: null, interval };
+  }
+
+  async getSeriesByPreset(
+    symbol: string,
+    preset: BinanceChartPreset,
+    limit?: number,
+    live = true,
+  ): Promise<{ points: BinanceCandleDto[]; interval: BinanceKlineInterval }> {
+    this.checkIfEnabled();
+
+    const upper = symbol.toUpperCase();
+    const interval = BINANCE_PRESET_TO_INTERVAL[preset];
+    const need = Math.ceil(
+      BINANCE_PRESET_WINDOW_MS[preset] / intervalMs(interval),
+    );
+    const lim = Math.min(Math.max(limit ?? need, 10), BINANCE_MAX_KLINE_LIMIT);
+    const { points } = await this.fetchSeriesRaw(upper, interval, lim);
+
+    const base = await this.getBaselineOpen(upper, preset);
+    const baselineOpen = base.baselineOpen;
+    const source: BinanceCandleDto['source'] = live ? 'rest' : 'rest';
+
+    const decorated = points.map((p) => ({
+      ...p,
+      source,
+      changePercent:
+        baselineOpen && baselineOpen > 0
+          ? ((Number(p.close) - baselineOpen) / baselineOpen) * 100
+          : null,
+    }));
+
+    return { points: decorated, interval };
+  }
+
+  async getMidPrices(symbols: string[]) {
+    this.checkIfEnabled();
+
+    const upperSymbols = symbols.map((s) => s.toUpperCase());
+    const response = await this.http.get(BINANCE_BOOK_TICKER_ENDPOINT, {
+      params: { symbols: JSON.stringify(upperSymbols) },
+    });
+
+    const data = Array.isArray(response.data) ? response.data : [response.data];
+
+    return data.map((entry: BinanceBookTicker) => {
+      const bid = Number(entry.bidPrice);
+      const ask = Number(entry.askPrice);
+      const mid = Number.isFinite(bid) && Number.isFinite(ask)
+        ? ((bid + ask) / 2).toString()
+        : null;
+      return {
+        symbol: entry.symbol,
+        price: mid,
+        source: 'rest:mid' as const,
+      };
+    });
+  }
+
+  async getSeriesByPresetRange(
+    symbol: string,
+    preset: BinanceChartPreset,
+    opts: { startTime?: number; endTime?: number; limit?: number } = {},
+  ): Promise<{ points: BinanceCandleDto[]; interval: BinanceKlineInterval }> {
+    this.checkIfEnabled();
+
+    const upper = symbol.toUpperCase();
+    const interval = BINANCE_PRESET_TO_INTERVAL[preset];
+    const limit = Math.min(
+      Math.max(opts.limit ?? BINANCE_MAX_KLINE_LIMIT, 1),
+      BINANCE_MAX_KLINE_LIMIT,
+    );
+    const now = Date.now();
+
+    const response = await this.http.get(BINANCE_KLINES_ENDPOINT, {
+      params: {
+        symbol: upper,
+        interval,
+        limit,
+        startTime: opts.startTime,
+        endTime: opts.endTime,
+      },
+    });
+
+    const points: BinanceCandleDto[] = (response.data as BinanceKlineRaw[]).map(
+      (c) => ({
+        openTime: c[0],
+        open: c[1],
+        high: c[2],
+        low: c[3],
+        close: c[4],
+        volume: c[5],
+        closeTime: c[6],
+        closed: now >= c[6],
+        source: 'rest',
+      }),
+    );
+
+    return { points, interval };
+  }
+
+  private async fetchBaselineOpen(
+    symbol: string,
+    interval: BinanceKlineInterval,
+    anchorStart: number,
+  ): Promise<number | null> {
+    const response = await this.http.get(BINANCE_KLINES_ENDPOINT, {
+      params: {
+        symbol: symbol.toUpperCase(),
+        interval,
+        limit: 2,
+        startTime: anchorStart,
+      },
+    });
+    const ks = response.data as BinanceKlineRaw[];
+    return ks.length ? Number(ks[0][1]) : null;
+  }
+
+  private async fetchSeriesRaw(
+    symbol: string,
+    interval: BinanceKlineInterval,
+    limit: number,
+  ): Promise<{ points: BinanceCandleDto[]; interval: BinanceKlineInterval }> {
+    const now = Date.now();
+    const response = await this.http.get(BINANCE_KLINES_ENDPOINT, {
+      params: { symbol, interval, limit },
+    });
+
+    let points: BinanceCandleDto[] = (response.data as BinanceKlineRaw[]).map(
+      (c) => ({
+        openTime: c[0],
+        open: c[1],
+        high: c[2],
+        low: c[3],
+        close: c[4],
+        volume: c[5],
+        closeTime: c[6],
+        closed: now >= c[6],
+        source: 'rest',
+      }),
+    );
+
+    if (points.length > limit) {
+      points = points.slice(-limit);
+    }
+
+    return { points, interval };
+  }
+}

--- a/src/providers/binance/config/binance-config.type.ts
+++ b/src/providers/binance/config/binance-config.type.ts
@@ -1,0 +1,6 @@
+export type BinanceConfig = {
+  baseUrl: string;
+  enable: boolean;
+  requestTimeoutMs: number;
+  defaultQuoteAsset: string;
+};

--- a/src/providers/binance/config/binance-endpoints.config.ts
+++ b/src/providers/binance/config/binance-endpoints.config.ts
@@ -1,0 +1,1 @@
+// Reserved for future ApiGateway integration with Binance REST endpoints.

--- a/src/providers/binance/config/binance.config.ts
+++ b/src/providers/binance/config/binance.config.ts
@@ -1,0 +1,52 @@
+import { IsBoolean, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { BinanceConfig } from './binance-config.type';
+import {
+  BINANCE_BASE_URL,
+  BINANCE_DEFAULT_QUOTE_ASSET,
+  BINANCE_ENABLE,
+  BINANCE_REQUEST_TIMEOUT_MS,
+} from '../types/binance-const.type';
+import { createToggleableConfig } from '../../../config/config.helper';
+
+class BinanceEnvironmentVariablesValidator {
+  @IsString()
+  @IsOptional()
+  BINANCE_BASE_URL?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  BINANCE_ENABLE?: boolean;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  BINANCE_REQUEST_TIMEOUT_MS?: number;
+
+  @IsString()
+  @IsOptional()
+  BINANCE_DEFAULT_QUOTE_ASSET?: string;
+}
+
+const defaults: BinanceConfig = {
+  enable: BINANCE_ENABLE,
+  baseUrl: BINANCE_BASE_URL,
+  requestTimeoutMs: BINANCE_REQUEST_TIMEOUT_MS,
+  defaultQuoteAsset: BINANCE_DEFAULT_QUOTE_ASSET,
+};
+
+export default createToggleableConfig<
+  BinanceConfig,
+  BinanceEnvironmentVariablesValidator
+>('binance', BinanceEnvironmentVariablesValidator, defaults, {
+  enableKey: 'enable',
+  enableEnvKey: 'BINANCE_ENABLE',
+  mapEnabledConfig: (env) => {
+    return {
+      baseUrl: env.BINANCE_BASE_URL || defaults.baseUrl,
+      requestTimeoutMs:
+        env.BINANCE_REQUEST_TIMEOUT_MS ?? defaults.requestTimeoutMs,
+      defaultQuoteAsset:
+        env.BINANCE_DEFAULT_QUOTE_ASSET || defaults.defaultQuoteAsset,
+    } satisfies Partial<BinanceConfig>;
+  },
+});

--- a/src/providers/binance/dto/binance-account.dto.ts
+++ b/src/providers/binance/dto/binance-account.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class BinanceSupportedAssetsQueryDto {
+  @ApiProperty({ example: 'USDT', required: false, default: 'USDT' })
+  @IsOptional()
+  @IsString()
+  quoteAsset?: string;
+}
+
+export class BinanceSupportedAssetDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: 'BTC' })
+  baseAsset!: string;
+
+  @ApiProperty({ example: 'USDT' })
+  quoteAsset!: string;
+}

--- a/src/providers/binance/dto/binance-chart.dto.ts
+++ b/src/providers/binance/dto/binance-chart.dto.ts
@@ -1,0 +1,141 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { BinanceChartPreset } from '../types/binance-const.type';
+import { BinanceCandleDto } from './binance-klines.dto';
+
+export class BinanceChartHeaderQueryDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  @IsString()
+  symbol!: string;
+
+  @ApiProperty({
+    example: 'today',
+    required: false,
+    default: 'today',
+  })
+  @IsOptional()
+  @IsString()
+  preset?: BinanceChartPreset;
+}
+
+export class BinanceChartHeaderDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: '65000.12', nullable: true })
+  price!: string | null;
+
+  @ApiProperty({ example: 4.5, nullable: true })
+  changePercent!: number | null;
+
+  @ApiProperty({ example: 'today' })
+  preset!: BinanceChartPreset;
+
+  @ApiProperty({ example: '5m' })
+  interval!: string;
+}
+
+export class BinanceChartSeriesQueryDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  @IsString()
+  symbol!: string;
+
+  @ApiProperty({ example: 'today', required: false, default: 'today' })
+  @IsOptional()
+  @IsString()
+  preset?: BinanceChartPreset;
+
+  @ApiProperty({ example: 300, required: false })
+  @IsOptional()
+  @IsString()
+  limit?: string;
+}
+
+export class BinanceChartSeriesDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: 'today' })
+  preset!: BinanceChartPreset;
+
+  @ApiProperty({ example: '5m' })
+  interval!: string;
+
+  @ApiProperty({
+    example: { open: 65000, time: 1710000000000 },
+    nullable: true,
+  })
+  baseline!: { open: number | null; time: number | null };
+
+  @ApiProperty({ example: '65050.21', nullable: true })
+  price!: string | null;
+
+  @ApiProperty({ example: 1.5, nullable: true })
+  changePercent!: number | null;
+
+  @ApiProperty({ type: [BinanceCandleDto] })
+  points!: BinanceCandleDto[];
+}
+
+export class BinanceChartMidPriceQueryDto {
+  @ApiProperty({ example: 'BTCUSDT,ETHUSDT' })
+  @IsString()
+  symbols!: string;
+}
+
+export class BinanceChartMidPriceDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: '65020.21', nullable: true })
+  price!: string | null;
+
+  @ApiProperty({ enum: ['rest:mid', 'rest:last'] })
+  source!: 'rest:mid' | 'rest:last';
+}
+
+export class BinanceChartSeriesRangeQueryDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  @IsString()
+  symbol!: string;
+
+  @ApiProperty({ example: 'today', required: false, default: 'today' })
+  @IsOptional()
+  @IsString()
+  preset?: BinanceChartPreset;
+
+  @ApiProperty({ example: 1710000000000, required: false })
+  @IsOptional()
+  @IsString()
+  startTime?: string;
+
+  @ApiProperty({ example: 1710003600000, required: false })
+  @IsOptional()
+  @IsString()
+  endTime?: string;
+
+  @ApiProperty({ example: 1000, required: false })
+  @IsOptional()
+  @IsString()
+  limit?: string;
+}
+
+export class BinanceChartSeriesRangeDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: 'today' })
+  preset!: BinanceChartPreset;
+
+  @ApiProperty({ example: '5m' })
+  interval!: string;
+
+  @ApiProperty({ type: [BinanceCandleDto] })
+  points!: BinanceCandleDto[];
+
+  @ApiProperty({
+    example: { startTime: 1710000000000, endTime: 1710003600000 },
+    nullable: true,
+  })
+  range!: { startTime?: number; endTime?: number };
+}

--- a/src/providers/binance/dto/binance-klines.dto.ts
+++ b/src/providers/binance/dto/binance-klines.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class BinanceHistoryQueryDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  @IsString()
+  symbol!: string;
+
+  @ApiProperty({ example: '1m', required: false, default: '1m' })
+  @IsOptional()
+  @IsString()
+  interval?: string;
+
+  @ApiProperty({ example: 100, required: false, default: 100 })
+  @IsOptional()
+  @IsString()
+  limit?: string;
+
+  @ApiProperty({
+    description: 'Use live stream cache when available',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsString()
+  live?: string;
+}
+
+export class BinanceCandleDto {
+  @ApiProperty({ example: 1710000000000 })
+  openTime!: number;
+
+  @ApiProperty({ example: '65000.12' })
+  open!: string;
+
+  @ApiProperty({ example: '65500.99' })
+  high!: string;
+
+  @ApiProperty({ example: '64900.01' })
+  low!: string;
+
+  @ApiProperty({ example: '65200.45' })
+  close!: string;
+
+  @ApiProperty({ example: '1234.56' })
+  volume!: string;
+
+  @ApiProperty({ example: 1710000300000 })
+  closeTime!: number;
+
+  @ApiProperty({ enum: ['rest', 'cache', 'ws'], required: false })
+  source?: 'rest' | 'cache' | 'ws';
+
+  @ApiProperty({ required: false })
+  closed?: boolean;
+
+  @ApiProperty({ required: false, nullable: true })
+  changePercent?: number | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  prevChangePercent?: number | null;
+}

--- a/src/providers/binance/dto/binance-price.dto.ts
+++ b/src/providers/binance/dto/binance-price.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class BinancePriceQueryDto {
+  @ApiProperty({
+    description: 'Comma-separated symbols in BASE_QUOTE format (e.g. BTC_USDT)',
+    example: 'BTC_USDT,ETH_USDT',
+  })
+  @IsString()
+  symbols!: string;
+
+  @ApiProperty({
+    description: 'Use live price stream when available',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsString()
+  live?: string;
+}
+
+export class BinancePriceDto {
+  @ApiProperty({ example: 'BTCUSDT' })
+  symbol!: string;
+
+  @ApiProperty({ example: '65000.12', nullable: true })
+  price!: string | null;
+
+  @ApiProperty({ enum: ['rest', 'cache'] })
+  source!: 'rest' | 'cache';
+}

--- a/src/providers/binance/types/binance-const.type.ts
+++ b/src/providers/binance/types/binance-const.type.ts
@@ -1,0 +1,63 @@
+export const BINANCE_ENABLE = false;
+
+export const BINANCE_BASE_URL = 'https://api.binance.com';
+
+export const BINANCE_REQUEST_TIMEOUT_MS = 10_000;
+
+export const BINANCE_DEFAULT_QUOTE_ASSET = 'USDT';
+
+export const BINANCE_MAX_KLINE_LIMIT = 1000;
+
+export type BinanceChartPreset = 'today' | 'week' | 'month' | 'year';
+
+export type BinanceKlineInterval =
+  | '1m'
+  | '3m'
+  | '5m'
+  | '15m'
+  | '30m'
+  | '1h'
+  | '2h'
+  | '4h'
+  | '6h'
+  | '8h'
+  | '12h'
+  | '1d'
+  | '3d'
+  | '1w'
+  | '1M';
+
+export const BINANCE_PRESET_TO_INTERVAL: Record<
+  BinanceChartPreset,
+  BinanceKlineInterval
+> = {
+  today: '5m',
+  week: '15m',
+  month: '1h',
+  year: '1d',
+};
+
+export const BINANCE_PRESET_WINDOW_MS: Record<BinanceChartPreset, number> = {
+  today: 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000,
+  year: 365 * 24 * 60 * 60 * 1000,
+};
+
+export const BINANCE_VALID_INTERVALS: BinanceKlineInterval[] = [
+  '1m',
+  '3m',
+  '5m',
+  '15m',
+  '30m',
+  '1h',
+  '2h',
+  '4h',
+  '6h',
+  '8h',
+  '12h',
+  '1d',
+  '3d',
+  '1w',
+  '1M',
+];


### PR DESCRIPTION
### Motivation
- Provide a Binance-backed provider to expose market data and chart primitives (prices, klines, mid-price and series) analogous to the existing CMC integration.

### Description
- Add a `BinanceModule` containing `BinanceService` and `BinanceController` which expose REST endpoints `GET /binance/price`, `/history`, `/supported-assets`, `/chart/header`, `/chart/series`, `/chart/mid-price`, and `/chart/series-range` and corresponding DTOs under `src/providers/binance/dto`.
- Implement HTTP-based Binance logic in `BinanceService` using `axios` with helpers and types in `src/providers/binance/*`, including `normalizeAssetPair`, `berlinCalendarAnchorStart`, `intervalMs` and a new `fetchSeriesRaw` to fetch and normalize kline data.
- Add configuration and types for the provider in `src/providers/binance/config` and wire `binanceConfig` and `BinanceModule` into the app `ConfigModule` and `AppModule`, and add `binance` to the `AllConfigType` in `src/config/config.type.ts`.
- Improve validation and error handling by normalizing symbol inputs in controller/service and throwing `BadRequestException` with clear messages for invalid symbol formats.

### Testing
- No automated tests were executed for this change.
- Only basic file creation and static edits were made; no runtime or integration validation was performed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2ae47f908320a4f1a8f5404d2b1b)